### PR TITLE
Put Bisq 2 api into an own container

### DIFF
--- a/docker/bisq2-api/Dockerfile
+++ b/docker/bisq2-api/Dockerfile
@@ -1,0 +1,37 @@
+# Use JDK 21 as base image
+FROM eclipse-temurin:21-jdk
+
+# Set working directory
+WORKDIR /opt/bisq2
+
+# Install git and other dependencies
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone the specific branch from the forked repository
+RUN git clone --recurse-submodules -b add-support-api https://github.com/hiciefte/bisq2.git .
+
+# Build the application
+RUN ./gradlew :apps:http-api-app:build
+
+# Create a non-root user
+RUN useradd -m -s /bin/bash bisq-support && \
+    chown -R bisq-support:bisq-support /opt/bisq2
+
+# Switch to non-root user
+USER bisq-support
+
+# Set environment variables
+ENV BISQ_DATA_DIR=/opt/bisq2/data
+ENV JAVA_OPTS="-Xmx1g"
+
+# Copy custom configuration
+COPY --chown=bisq-support:bisq-support config/http_api_app.conf /opt/bisq2/apps/http-api-app/src/main/resources/http_api_app.conf
+
+# Expose the API port
+EXPOSE 8090
+
+# Start the API service
+CMD ["./gradlew", ":apps:http-api-app:run", "-Djava.awt.headless=true"] 

--- a/docker/bisq2-api/config/http_api_app.conf
+++ b/docker/bisq2-api/config/http_api_app.conf
@@ -1,0 +1,39 @@
+application {
+    appName = "Bisq2"
+    devMode = false
+    devModeReputationScore = 0
+    keyIds = "E222AA02,387C8307"
+    ignoreSigningKeyInResourcesCheck = false
+    ignoreSignatureVerification = false
+    memoryReportIntervalSec = 120
+    includeThreadListInMemoryReport = true
+
+    restApi = {
+        enabled = false
+        server = {
+            protocol = "http://"
+            host = "0.0.0.0"
+            port = 8082
+        }
+        localhostOnly = false    // Allow access from any interface
+        whiteListEndPoints = []
+        blackListEndPoints = []
+        supportedAuth = []
+    }
+
+    websocket = {
+        enabled = true
+        includeRestApi = true
+        server = {
+            protocol = "http://"
+            host = "0.0.0.0"
+            port = 8090
+        }
+        localhostOnly = false    // Allow access from any interface
+        whiteListEndPoints = []
+        blackListEndPoints = []
+        supportedAuth = []
+    }
+
+    // ... rest of the configuration remains the same ...
+} 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,38 @@ services:
           cpus: '0.25'
           memory: 128M
 
+  # Bisq2 API service
+  bisq2-api:
+    build:
+      context: ./bisq2-api
+      dockerfile: Dockerfile
+    restart: always
+    volumes:
+      - bisq2-data:/opt/bisq2/data
+    environment:
+      - BISQ_DATA_DIR=/opt/bisq2/data
+      - JAVA_OPTS=-Xmx1g
+    expose:
+      - "8090"
+    networks:
+      - bisq-support-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8090/api/v1/support/export/csv" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+
   # API backend
   api:
     build:
@@ -68,10 +100,8 @@ services:
       - "8000"
     networks:
       - bisq-support-network
-    # Add extra_hosts to map host.docker.internal
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     healthcheck:
+      # Reverted healthcheck to use service name
       test: [ "CMD", "curl", "-f", "http://api:8000/health" ]
       interval: 30s
       timeout: 10s
@@ -236,9 +266,6 @@ services:
       - api
     networks:
       - bisq-support-network
-    # Add extra_hosts to map host.docker.internal
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     logging:
       driver: "json-file"
       options:
@@ -250,6 +277,8 @@ volumes:
   grafana-data:
   web_node_modules:
     name: bisq2-web-node-modules
+  bisq2-data:
+    name: bisq2-data
 
 networks:
   bisq-support-network:

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -1,0 +1,101 @@
+# Environment Configuration
+
+This document details the environment variables used by the Bisq Support Agent project. These variables are used by the deployment/update scripts and within the Docker containers.
+
+## Deployment/Update Script Variables
+
+These variables are typically set in the shell or sourced from `/etc/bisq-support/deploy.env` before running `scripts/deploy.sh` or `scripts/update.sh`.
+
+### Required Script Variables
+
+*   **`BISQ_SUPPORT_REPO_URL`**
+    *   Description: The Git repository URL for the Bisq Support Agent project.
+    *   Example: `git@github.com:user/bisq2-support-agent.git`
+*   **`BISQ2_REPO_URL`**
+    *   Description: The Git repository URL for the Bisq 2 project.
+    *   Example: `git@github.com:user/bisq2.git`
+*   **`BISQ_SUPPORT_INSTALL_DIR`**
+    *   Description: The absolute path on the server where the Bisq Support Agent code will be cloned/installed.
+    *   Example: `/opt/bisq-support`
+*   **`BISQ2_INSTALL_DIR`**
+    *   Description: The absolute path on the server where the Bisq 2 code will be cloned/installed.
+    *   Example: `/opt/bisq2`
+
+### Optional Script Variables
+
+*   **`BISQ_SUPPORT_SECRETS_DIR`**
+    *   Description: The absolute path to store generated secrets (like API keys, passwords).
+    *   Default: `$BISQ_SUPPORT_INSTALL_DIR/secrets`
+*   **`BISQ_SUPPORT_LOG_DIR`**
+    *   Description: The absolute path for storing host-level logs (like deployment script logs, *not* application logs inside Docker).
+    *   Default: `$BISQ_SUPPORT_INSTALL_DIR/logs`
+*   **`BISQ_SUPPORT_SSH_KEY_PATH`**
+    *   Description: The absolute path to the private SSH key used for authenticating with Git repositories.
+    *   Default: `$HOME/.ssh/bisq2_support_agent` (Note: `$HOME` resolves to the home directory of the user running the script, typically `/root` when using `sudo`)
+*   **`BISQ2_API_PORT`**
+    *   Description: The port on the host machine that the Bisq 2 API service (running natively via systemd) will listen on. This port also needs to be opened in the firewall (`ufw`).
+    *   Default: `8090`
+
+## Docker Container Variables (`docker/.env`)
+
+These variables configure the application services running inside Docker containers. They are primarily set in the `docker/.env` file located within the installation directory (`$BISQ_SUPPORT_INSTALL_DIR/docker/.env`). The deployment script copies `docker/.env.example` if `.env` doesn't exist and injects some secrets.
+
+*   **`OPENAI_API_KEY`**
+    *   Description: (Required) Your API key from OpenAI, used for the primary RAG and embedding models.
+*   **`OPENAI_MODEL`**
+    *   Description: The OpenAI model ID to use for generating chat responses.
+    *   Default: `o3-mini`
+*   **`OPENAI_EMBEDDING_MODEL`**
+    *   Description: The OpenAI model ID to use for creating text embeddings.
+    *   Default: `text-embedding-3-small`
+*   **`MAX_TOKENS`**
+    *   Description: The maximum number of tokens to generate in an OpenAI completion.
+    *   Default: `4096`
+*   **`LLM_PROVIDER`**
+    *   Description: Specifies which Language Model provider to use.
+    *   Values: `openai` or `xai`
+    *   Default: `openai`
+*   **`XAI_API_KEY`**
+    *   Description: (Required if `LLM_PROVIDER=xai`) Your API key from xAI.
+*   **`XAI_MODEL`**
+    *   Description: (Used if `LLM_PROVIDER=xai`) The xAI model ID to use.
+    *   Default: `llama3-70b-8192`
+*   **`XAI_API_BASE_URL`**
+    *   Description: (Used if `LLM_PROVIDER=xai`) The base URL for the xAI API.
+    *   Default: `https://api.xai.com/v1`
+*   **`ADMIN_API_KEY`**
+    *   Description: A secret key required to access administrative API endpoints (e.g., feedback processing). The deployment script generates a random key and stores it in `$BISQ_SUPPORT_SECRETS_DIR/admin_api_key`, then injects it into `.env`.
+    *   Default in `.env.example`: `dev_admin_key`
+*   **`DEBUG`**
+    *   Description: Set to `true` to enable debug mode for the API (provides more verbose error output). Should be `false` in production.
+    *   Default: `false`
+*   **`CORS_ORIGINS`**
+    *   Description: A comma-separated list of origins (URLs) allowed to make requests to the API. Use `*` for wide-open access (not recommended for production).
+    *   Default: `http://localhost:3000,http://127.0.0.1:3000`
+*   **`DATA_DIR`**
+    *   Description: The path *inside the API container* where persistent data (wiki, FAQs, vectorstore, feedback) is stored/mounted.
+    *   Default: `/app/api/data` (maps to `$BISQ_SUPPORT_INSTALL_DIR/api/data` on the host via Docker volume mounts)
+*   **`EXPOSE_API_PORT`**
+    *   Description: Internal port used by the API container.
+    *   Default: `8000`
+*   **`EXPOSE_PROMETHEUS_PORT`**
+    *   Description: Internal port used by the Prometheus container.
+    *   Default: `9090`
+*   **`EXPOSE_GRAFANA_PORT`**
+    *   Description: Internal port used by the Grafana container. (Note: The *external* port is configured in `docker-compose.yml`).
+    *   Default: `3001`
+*   **`GRAFANA_ADMIN_USER`**
+    *   Description: The username for the initial Grafana admin user.
+    *   Default: `admin`
+*   **`GRAFANA_ADMIN_PASSWORD`**
+    *   Description: The password for the initial Grafana admin user. The deployment script generates a random password and stores it in `$BISQ_SUPPORT_SECRETS_DIR/grafana_admin_password`, then injects it into `.env`.
+    *   Default in `.env.example`: `securepassword`
+*   **`PROMETHEUS_BASIC_AUTH_USERNAME`**
+    *   Description: Username for basic authentication if configured for Prometheus (current setup might not use it).
+    *   Default: `admin`
+*   **`PROMETHEUS_BASIC_AUTH_PASSWORD`**
+    *   Description: Password for basic authentication if configured for Prometheus.
+    *   Default: `prometheuspassword`
+*   **`NEXT_PUBLIC_PROJECT_NAME`**
+    *   Description: A name for the project, potentially used in the UI.
+    *   Default: `Bisq 2 Support Agent` 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Bisq2 HTTP API service, including a dedicated Dockerfile and configuration for deployment.
  - Introduced a Docker Compose service for the Bisq2 API, with health checks, resource limits, and persistent data storage.
- **Documentation**
  - Added comprehensive documentation outlining environment variables for deployment scripts and Docker containers.
- **Chores**
  - Updated Docker Compose settings, removing unused host mappings and refining health checks for existing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->