### PR TITLE
Fix FastAPI startup CancelledError by removing deprecated event handler

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -161,12 +161,7 @@ app.add_middleware(
 
 # Set up Prometheus metrics
 instrumentator = Instrumentator().instrument(app)
-
-
-@app.on_event("startup")
-async def startup():
-    # Initialize the instrumentator but don't expose it
-    logger.info("Prometheus metrics instrumentation initialized")
+logger.info("Prometheus metrics instrumentation initialized")
 
 
 # Create a dedicated metrics endpoint


### PR DESCRIPTION
## Summary
- Remove deprecated `@app.on_event("startup")` decorator that was conflicting with the lifespan context manager
- Fix intermittent startup failures where the API container would exit with `CancelledError`
- Move Prometheus instrumentation initialization to module level

## Problem
The API container was experiencing intermittent startup failures with `asyncio.exceptions.CancelledError` during the lifespan event handling. This was caused by a race condition between:
- Modern `lifespan` context manager (lines 54-98 in main.py)
- Deprecated `@app.on_event("startup")` handler (lines 166-170)

## Solution
- Removed the deprecated event handler completely
- Moved Prometheus metrics initialization to module level
- Now uses only the lifespan context manager for application lifecycle management

## Test plan
- [x] Build and test locally - containers start successfully without CancelledError
- [x] Verify API container reaches healthy status
- [x] Confirm all services initialize properly in logs
- [ ] Deploy to server and verify startup stability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified application startup by initializing metrics at module load instead of during the startup phase, reducing startup-time logs and side effects. No user-facing changes.
* **Chores**
  * Removed obsolete startup handler related to initialization logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->