### PR TITLE
Update README with SQLite feedback documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ pnpm-lock.yaml
 /.playwright-mcp/
 # Git worktrees directory - used for parallel feature development
 /.trees/
+onion-keys/

--- a/README.md
+++ b/README.md
@@ -170,10 +170,21 @@ The project uses the following data directories within `api/data/`:
 
 -   `wiki/`: Contains wiki documents for the RAG knowledge base.
 -   `vectorstore/`: Stores vector embeddings for semantic search.
--   `feedback/`: Stores user feedback.
+-   `feedback.db`: SQLite database storing user feedback (automatically created on first run).
 -   `extracted_faq.jsonl`: Stores FAQs automatically generated from support chats.
 
-These are automatically created during deployment. For local development, create them manually if needed: `mkdir -p api/data/{wiki,vectorstore,feedback}`.
+These are automatically created during deployment. For local development, create them manually if needed: `mkdir -p api/data/{wiki,vectorstore}`.
+
+### Feedback Storage Migration
+
+The feedback system has been migrated from JSONL files to SQLite for better data integrity and query performance:
+
+-   **SQLite Database**: `api/data/feedback.db` - Primary feedback storage (automatically created)
+-   **Database Schema**: Includes tables for feedback entries, conversation history, metadata, and issues
+-   **Migration**: Existing JSONL feedback files can be migrated using `python -m app.scripts.migrate_feedback_to_sqlite`
+-   **Permissions**: The database file must be writable by the API container user (UID 1001 in production)
+
+For new deployments, no migration is needed - the database will be created automatically on first startup.
 
 ## RAG System Content
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The feedback system has been migrated from JSONL files to SQLite for better data
 -   **SQLite Database**: `api/data/feedback.db` - Primary feedback storage (automatically created)
 -   **Database Schema**: Includes tables for feedback entries, conversation history, metadata, and issues
 -   **Migration**: Existing JSONL feedback files can be migrated using `python -m app.scripts.migrate_feedback_to_sqlite`
--   **Permissions**: The database file must be writable by the API container user (UID 1001 in production)
+-   **Permissions**: The database file must be writable by the API container user (UID 1001, the `bisq-support` user in production). If you encounter permission errors, fix ownership with: `sudo chown 1001:1001 api/data/feedback.db`
 
 For new deployments, no migration is needed - the database will be created automatically on first startup.
 


### PR DESCRIPTION
## Summary
Updates README.md to document the SQLite feedback storage migration that was implemented in PR #68.

## Changes
- Updated Data Directory Structure section to reflect SQLite database usage
- Added new "Feedback Storage Migration" subsection with:
  - SQLite database location and automatic creation
  - Database schema description
  - Migration instructions for existing JSONL files
  - Permission requirements for production deployment

## Context
PR #68 migrated the feedback system from JSONL files to SQLite for better data integrity and query performance. This PR updates the documentation to reflect those changes and help developers understand the new storage system.

## Documentation Impact
- Developers know the feedback system now uses SQLite
- Clear migration path for existing deployments
- Permission requirements documented for production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance to use a SQLite feedback database (feedback.db) instead of a folder-based store.
  * Added a “Feedback Storage Migration” section with schema overview, migration command from JSONL, and permission notes.
  * Clarified that new deployments auto-create the database; no feedback directory needed.
  * Updated local setup to only create wiki and vectorstore directories.

* **Chores**
  * Added onion-keys/ to .gitignore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->