### PR TITLE
Fix RAG system returning Bisq 1 info for Bisq 2 queries

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,8 @@
+# CVE-2025-6985: XXE vulnerability in HTMLSectionSplitter class
+# This vulnerability affects the HTMLSectionSplitter class in langchain-text-splitters 0.3.x
+# which uses unsafe XSLT parsing. Our codebase only uses RecursiveCharacterTextSplitter,
+# not HTMLSectionSplitter, so we are not affected by this vulnerability.
+# The only fix is version 1.0.0a1 (alpha), which may have breaking changes.
+# Suppressing until a stable 1.0.0 release is available.
+# Reference: https://github.com/advisories/GHSA-m42m-m8cr-8m58
+CVE-2025-6985

--- a/api/app/services/simplified_rag_service.py
+++ b/api/app/services/simplified_rag_service.py
@@ -22,12 +22,16 @@ from app.core.config import get_settings
 from app.utils.logging import redact_pii
 from fastapi import Request
 from langchain.prompts import ChatPromptTemplate
+
 # Vector store and embeddings
 from langchain_chroma import Chroma
+
 # Core LangChain imports
 from langchain_core.documents import Document
+
 # LLM providers
 from langchain_openai import OpenAIEmbeddings
+
 # Text splitter
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -74,7 +74,7 @@ docopt==0.6.2
     # via mwcli
 durationpy==0.10
     # via kubernetes
-fastapi==0.118.0
+fastapi==0.118.1
     # via -r api/requirements.in
 filelock==3.19.1
     # via huggingface-hub
@@ -161,7 +161,7 @@ langchain==0.3.27
     #   langchain-community
 langchain-chroma==0.2.6
     # via -r api/requirements.in
-langchain-community==0.3.30
+langchain-community==0.3.31
     # via -r api/requirements.in
 langchain-core==0.3.78
     # via
@@ -238,7 +238,7 @@ numpy==2.3.3
     #   scipy
 oauthlib==3.3.1
     # via requests-oauthlib
-onnxruntime==1.23.0
+onnxruntime==1.23.1
     # via chromadb
 openai==1.109.1
     # via
@@ -517,7 +517,7 @@ uvloop==0.21.0
     # via uvicorn
 watchfiles==1.1.0
     # via uvicorn
-websocket-client==1.8.0
+websocket-client==1.9.0
     # via kubernetes
 websockets==15.0.1
     # via uvicorn

--- a/web/src/app/admin/manage-feedback/page.tsx
+++ b/web/src/app/admin/manage-feedback/page.tsx
@@ -787,7 +787,7 @@ export default function ManageFeedbackPage() {
               )}
 
               {/* Conversation History */}
-              {selectedFeedback.conversation_history && (
+              {selectedFeedback.conversation_history && selectedFeedback.conversation_history.length > 1 && (
                 <ConversationHistory messages={selectedFeedback.conversation_history} />
               )}
 
@@ -924,7 +924,7 @@ export default function ManageFeedbackPage() {
                   </div>
                 </div>
               )}
-              {selectedFeedbackForFAQ?.conversation_history && (
+              {selectedFeedbackForFAQ?.conversation_history && selectedFeedbackForFAQ.conversation_history.length > 1 && (
                 <ConversationHistory messages={selectedFeedbackForFAQ.conversation_history} />
               )}
             </div>


### PR DESCRIPTION
## Summary
Fixes the issue where queries about Bisq 2 features (e.g., "How can I safely buy bitcoin on Bisq 2?") were returning incorrect Bisq 1 information about multisig escrow and security deposits instead of Bisq Easy's reputation-based model.

## Root Cause
The RAG system was using pure semantic similarity search without version metadata filtering. Bisq 1 pages like "Taking an offer" had very high semantic similarity to "buy bitcoin" queries, causing them to dominate the context even though they were tagged as Bisq 1 content.

## Changes

### 1. Multi-Stage Version-Priority Retrieval
- **New method**: `_retrieve_with_version_priority()` in `simplified_rag_service.py`
- **Stage 1**: Search Bisq 2 content first (k=6 documents)
- **Stage 2**: Add General content if needed (k=4 documents)  
- **Stage 3**: Only include Bisq 1 content as fallback (k=2 documents)
- Uses ChromaDB metadata filtering: `filter={"bisq_version": "Bisq 2"}`

### 2. Optimized Text Chunking
- Increased `chunk_size` from 1500 → 2000 characters
- Added MediaWiki section separators (`\n## `, `\n# `) to prioritize keeping sections intact
- Preserves complete "How to buy bitcoin on Bisq Easy" sections without fragmentation

### 3. Conversation History Fix (from previous commit)
- Fixed conversation history not displaying in feedback detail view
- Added explicit length checks matching overview page behavior

## Impact
- Bisq 2 queries now receive Bisq 2-specific guidance
- Reduces confusion between Bisq 1 (multisig, deposits) and Bisq 2 (reputation, no deposits)
- Larger chunks preserve contextual coherence

## Testing Plan
1. Deploy to production via `update.sh`
2. Test query: "How can I safely buy bitcoin on Bisq 2?"
3. Verify response describes Bisq Easy reputation-based model, not Bisq 1 multisig
4. Monitor user feedback for improved accuracy

## Notes
- Local testing was blocked by Docker permission issues (unrelated to these changes)
- Python syntax validated successfully (`python3 -m py_compile` passed)
- Changes are backward compatible with fallback to standard retrieval if filtering fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version-aware retrieval that prioritizes newer documentation for more accurate, context-rich answers.
  * Improved context assembly with larger, MediaWiki-aware text chunking for better relevance.

* **Bug Fixes**
  * Admin: Conversation history now renders only when multiple entries exist, preventing trivial/empty displays.

* **Security**
  * Suppressed a specific CVE advisory until a safe upstream fix is available.

* **Maintenance**
  * Updated backend dependencies for stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->