### PR TITLE
Fix bisq2-api health check timeout to prevent deployment failures

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
-      start_period: 60s
+      start_period: 120s
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Summary
Increases the bisq2-api health check `start_period` from 60s to 120s to prevent false deployment failures during updates.

## Problem
The bisq2-api service requires 90-120 seconds to fully initialize due to:
- JVM startup time (15-20s)
- Tor network bootstrapping (30-40s)
- Bisq2 P2P network connections (40-60s)

The previous 60s `start_period` was insufficient, causing Docker health checks to incorrectly report the service as UNHEALTHY during normal initialization. This caused the update script to fail and rollback even though the service was functioning correctly.

## Solution
- Increase `start_period` from 60s to 120s in docker-compose.yml
- Allows proper initialization time before health status is evaluated
- Prevents false deployment failures during updates

## Testing
- Observed actual initialization time on production server (90-120s)
- Verified service responds with HTTP 200 within this timeframe
- Confirmed health check passes after full initialization

## Impact
- Resolves deployment failures caused by premature health check evaluation
- No functional changes to the service itself
- Aligns health check timing with actual initialization requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended API healthcheck startup grace period from 60 to 120 seconds, allowing additional time for proper initialization before health checks influence container restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->