### PR TITLE
Fix FAQ extractor model naming inconsistency

### DIFF
--- a/api/app/services/faq/faq_extractor.py
+++ b/api/app/services/faq/faq_extractor.py
@@ -184,8 +184,8 @@ Output each FAQ as a single-line JSON object. No additional text or commentary."
 
         for attempt in range(max_retries):
             try:
-                # Build full model ID with provider prefix
-                model_id = f"openai:{self.settings.OPENAI_MODEL}"
+                # Use model ID directly - expects full provider:model format (e.g., "openai:gpt-4o-mini")
+                model_id = self.settings.OPENAI_MODEL
 
                 response = self.aisuite_client.chat.completions.create(
                     model=model_id,


### PR DESCRIPTION
## Problem

The FAQ extractor was incorrectly adding the `openai:` prefix to the `OPENAI_MODEL` environment variable, which already contains the full `provider:model` format (e.g., `openai:gpt-4o-mini`). This resulted in invalid model IDs like `openai:openai:gpt-4o-mini`, causing FAQ extraction failures.

## Root Cause

**Inconsistency between FAQ extractor and RAG service:**

- **FAQ extractor** (`faq_extractor.py:188`): Added prefix with `f"openai:{self.settings.OPENAI_MODEL}"`
- **RAG service** (`llm_provider.py:157`): Used model ID directly with `self.settings.OPENAI_MODEL`

With production setting `OPENAI_MODEL=openai:gpt-4o-mini`:
- FAQ extractor sent: `openai:openai:gpt-4o-mini` ❌ (invalid double prefix)
- RAG service sent: `openai:gpt-4o-mini` ✅ (correct)

## Solution

Changed FAQ extractor to use `OPENAI_MODEL` directly, matching the RAG service behavior which correctly expects the full `provider:model` format in the environment variable.

## Changes

- `api/app/services/faq/faq_extractor.py`: Removed automatic `openai:` prefix addition
- Updated comment to clarify expected format

## Testing

This fix ensures:
- ✅ FAQ extraction uses correct model ID format
- ✅ Consistency across all AISuite integrations
- ✅ No impact on RAG service (already using correct format)

## Impact

- **Before**: FAQ extraction would fail with model not found errors when new support messages arrive
- **After**: FAQ extraction will work correctly with the configured AISuite model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated model configuration handling. The model identifier must now include the provider prefix to function correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->