### PR TITLE
Fix bisq2-api health check timeout in deployments

### DIFF
--- a/scripts/lib/docker-utils.sh
+++ b/scripts/lib/docker-utils.sh
@@ -7,7 +7,11 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 source "$LIB_DIR/common.sh"
 
 # Configuration
-HEALTH_CHECK_RETRIES=${HEALTH_CHECK_RETRIES:-30}
+# Health check configuration for service startup verification
+# bisq2-api needs longer timeout due to Java startup + Bisq network initialization (typically 60-180s)
+# Formula: Initial wait (15s in update.sh) + (RETRIES × INTERVAL) should exceed Docker's start_period (120s for bisq2-api)
+# Recommended minimum: 180 seconds total = 15s + (90 × 2s) = 195 seconds
+HEALTH_CHECK_RETRIES=${HEALTH_CHECK_RETRIES:-90}
 HEALTH_CHECK_INTERVAL=${HEALTH_CHECK_INTERVAL:-2}
 
 # Function to check service health using docker compose ps

--- a/scripts/lib/git-utils.sh
+++ b/scripts/lib/git-utils.sh
@@ -238,7 +238,7 @@ restore_production_data() {
     local backup_dir="${2}"
 
     if [ -z "$backup_dir" ] || [ ! -d "$backup_dir" ]; then
-        log_warning "No backup directory specified or directory not found"
+        log_debug "No production data to restore (expected on initial deployment or when no data files exist)"
         return 0
     fi
 


### PR DESCRIPTION
## Problem

Production deployments consistently failed during bisq2-api health checks, causing automatic rollbacks. The bisq2-api service requires 60-180 seconds to initialize (Java startup + Bisq network synchronization), but the update.sh script only waited 75 seconds total before timing out.

**Configuration mismatch:**
- Docker health check: `start_period: 120s` (don't count failures for first 2 minutes)
- Script timeout: Only 75 seconds (15s initial wait + 30 retries × 2s)
- Actual startup time: ~60-180 seconds

## Solution

### 1. Increased Health Check Timeout
**File**: `scripts/lib/docker-utils.sh`

Changed `HEALTH_CHECK_RETRIES` from 30 to 90:
- **Before**: 15s + (30 × 2s) = 75 seconds total
- **After**: 15s + (90 × 2s) = 195 seconds total

This ensures the script timeout (195s) exceeds Docker's `start_period` (120s) and accommodates bisq2-api's actual startup requirements (60-180s).

### 2. Fixed Misleading Warning Message
**File**: `scripts/lib/git-utils.sh`

Changed backup restore warning from `log_warning` to `log_debug` in `restore_production_data()` function. Having no production data to restore is expected behavior during:
- Initial deployments
- When data files don't exist yet
- Successful deployments without rollback

## Testing

Verified on production server:
- Manual rebuild succeeded with bisq2-api becoming healthy after ~60 seconds
- Backup/restore functions work correctly with existing data files
- All services healthy after deployment

## Impact

This fix prevents false deployment failures and enables successful production updates when bisq2-api takes longer to initialize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default health check retry threshold to improve system resilience during deployment processes.
  * Updated data restoration error handling to adjust diagnostic logging levels while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->