### PR TITLE
Improve update script chat endpoint test reliability

### DIFF
--- a/scripts/lib/docker-utils.sh
+++ b/scripts/lib/docker-utils.sh
@@ -338,6 +338,11 @@ test_chat_endpoint() {
         http_code=$(echo "$response" | tail -n1)
         response=$(echo "$response" | sed '$d')
 
+        # Validate HTTP code is numeric (curl may fail with connection errors)
+        if ! [[ "$http_code" =~ ^[0-9]+$ ]]; then
+            http_code="000"
+        fi
+
         # Check if response contains expected fields
         if echo "$response" | jq -e '.answer and .sources and .response_time' > /dev/null 2>&1; then
             log_success "Chat endpoint test successful"


### PR DESCRIPTION
## Summary
- Add retry mechanism to chat endpoint test (5 retries × 10s delays)
- Fix 405 errors caused by API not fully initialized after health check passes

## Problem
The update script was failing with HTTP 405 during chat endpoint validation because:
1. Docker health check passes when API container is healthy
2. But FastAPI routes need additional time to initialize
3. Nginx returns 405 when it can't proxy to unresponsive backend

## Solution
- Increased retries from 3 to 5
- Increased delay between retries from 5s to 10s
- Total wait time: 50s (was 15s)
- Better error logging with HTTP status codes

## Test plan
- [x] Tested on production server with full rebuild
- [x] Chat endpoint test passes on first attempt with new timing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing infrastructure with improved retry logic for chat endpoint validation, ensuring more reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->