### PR TITLE
Fix docker compose build-arg flag usage in update.sh

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -326,8 +326,14 @@ apply_updates() {
         if [ "$API_REBUILD_NEEDED" = "true" ]; then
             log_info "Rebuilding API service..."
 
-            if ! docker compose -f "$COMPOSE_FILE" up -d --build --build-arg BUILD_ID="${BUILD_ID:-bisq-support-build}" --no-deps api; then
-                log_error "Failed to rebuild API service"
+            # Build with BUILD_ID for cache invalidation, then start
+            # Note: --build-arg only works with 'docker compose build', not 'up --build'
+            if ! docker compose -f "$COMPOSE_FILE" build --build-arg BUILD_ID="${BUILD_ID:-bisq-support-build}" api; then
+                log_error "Failed to build API service"
+                rollback_update "API rebuild failed"
+            fi
+            if ! docker compose -f "$COMPOSE_FILE" up -d --no-deps api; then
+                log_error "Failed to start API service"
                 rollback_update "API rebuild failed"
             fi
 
@@ -368,8 +374,14 @@ apply_updates() {
         if [ "$WEB_REBUILD_NEEDED" = "true" ]; then
             log_info "Rebuilding Web service..."
 
-            if ! docker compose -f "$COMPOSE_FILE" up -d --build --build-arg BUILD_ID="${BUILD_ID:-bisq-support-build}" --no-deps web; then
-                log_error "Failed to rebuild Web service"
+            # Build with BUILD_ID for cache invalidation, then start
+            # Note: --build-arg only works with 'docker compose build', not 'up --build'
+            if ! docker compose -f "$COMPOSE_FILE" build --build-arg BUILD_ID="${BUILD_ID:-bisq-support-build}" web; then
+                log_error "Failed to build Web service"
+                rollback_update "Web rebuild failed"
+            fi
+            if ! docker compose -f "$COMPOSE_FILE" up -d --no-deps web; then
+                log_error "Failed to start Web service"
                 rollback_update "Web rebuild failed"
             fi
 


### PR DESCRIPTION
## Summary
- Fix invalid `--build-arg` usage with `docker compose up --build`
- The `--build-arg` flag only works with `docker compose build`, not with `docker compose up --build`
- Separate the build and up commands for selective API and Web service rebuilds

## Problem
The deployment was failing with `unknown flag: --build-arg` error because:
```bash
docker compose up -d --build --build-arg BUILD_ID="..." --no-deps api
```
is invalid syntax.

## Solution
Changed to correct two-step approach:
```bash
docker compose build --build-arg BUILD_ID="..." api
docker compose up -d --no-deps api
```

## Test plan
- [ ] Deploy to production server using `update.sh`
- [ ] Verify API and Web services rebuild correctly
- [ ] Verify health checks pass after rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment automation with separated build and startup workflows, improved error detection with automatic rollback capabilities, and better logging for troubleshooting and system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->