### PR TITLE
Fix Grafana proxy to preserve /grafana/ path prefix

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -215,11 +215,13 @@ server {
     #------------------------------
     # Grafana Dashboard
     #------------------------------
+    # Grafana runs with GF_SERVER_SERVE_FROM_SUB_PATH=true, so it expects
+    # requests at /grafana/. Don't strip the prefix (no trailing slash in proxy_pass).
     location /grafana/ {
         limit_req zone=grafana burst=10 nodelay;
 
         set $grafana_upstream grafana:3000;
-        proxy_pass http://$grafana_upstream/;
+        proxy_pass http://$grafana_upstream;
 
         include /etc/nginx/conf.d/snippets/proxy-params.conf;
         include /etc/nginx/conf.d/snippets/connection-limits.conf;

--- a/docker/nginx/conf.d/default.prod.conf
+++ b/docker/nginx/conf.d/default.prod.conf
@@ -226,11 +226,13 @@ server {
     #------------------------------
     # Grafana Dashboard
     #------------------------------
+    # Grafana runs with GF_SERVER_SERVE_FROM_SUB_PATH=true, so it expects
+    # requests at /grafana/. Don't strip the prefix (no trailing slash in proxy_pass).
     location /grafana/ {
         limit_req zone=grafana burst=150 nodelay;
 
         set $grafana_upstream grafana:3000;
-        proxy_pass http://$grafana_upstream/;
+        proxy_pass http://$grafana_upstream;
 
         include /etc/nginx/conf.d/snippets/proxy-params.conf;
         include /etc/nginx/conf.d/snippets/connection-limits.conf;


### PR DESCRIPTION
## Summary
- Fix nginx proxy configuration for Grafana subpath routing
- Remove trailing slash from `proxy_pass` to preserve `/grafana/` path prefix
- Grafana runs with `GF_SERVER_SERVE_FROM_SUB_PATH=true` and expects requests at `/grafana/`

## Changes
- Updated `default.conf` and `default.prod.conf` nginx configurations
- Without trailing slash, nginx preserves the path and Grafana receives `/grafana/...`
- With trailing slash (before), nginx stripped the prefix causing redirect loops

## Test Plan
- [x] Verified Grafana loads at `http://<server>/grafana/`
- [x] Login page renders correctly
- [x] No more redirect loops to `localhost`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Grafana sub-path serving configuration to ensure requests are properly forwarded when accessing Grafana under the /grafana/ path. Updated reverse proxy settings across both production and standard deployment environments to align with sub-path serving expectations. This enhances the reliability of request forwarding behavior when serving Grafana through a sub-path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->