### PR TITLE
Add Grafana-specific security headers

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -225,8 +225,8 @@ server {
 
         include /etc/nginx/conf.d/snippets/proxy-params.conf;
         include /etc/nginx/conf.d/snippets/connection-limits.conf;
-        # Apply API-like security headers for Grafana (adjust as needed)
-        include /etc/nginx/conf.d/snippets/security-headers-api.conf;
+        # Grafana-specific security headers (allows loading scripts, styles, etc.)
+        include /etc/nginx/conf.d/snippets/security-headers-grafana.conf;
     }
 
     #------------------------------

--- a/docker/nginx/conf.d/default.prod.conf
+++ b/docker/nginx/conf.d/default.prod.conf
@@ -236,8 +236,8 @@ server {
 
         include /etc/nginx/conf.d/snippets/proxy-params.conf;
         include /etc/nginx/conf.d/snippets/connection-limits.conf;
-        # Apply API-like security headers for Grafana (adjust as needed)
-        include /etc/nginx/conf.d/snippets/security-headers-api.conf;
+        # Grafana-specific security headers (allows loading scripts, styles, etc.)
+        include /etc/nginx/conf.d/snippets/security-headers-grafana.conf;
         error_page 502 503 504 = @maintenance;
     }
 

--- a/docker/nginx/conf.d/snippets/security-headers-grafana.conf
+++ b/docker/nginx/conf.d/snippets/security-headers-grafana.conf
@@ -1,0 +1,12 @@
+# security-headers-grafana.conf
+# Security headers for Grafana dashboard - allows loading of Grafana's own assets
+
+# Content Security Policy allowing Grafana to function
+# Grafana needs to load scripts, styles, images, fonts, and make API calls
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:;" always;
+
+# Other security headers
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "SAMEORIGIN" always;  # Allow embedding within same origin
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Add dedicated security headers for Grafana dashboard
- The API security headers (`default-src 'none'`) were blocking Grafana's scripts, styles, and assets

## Changes
- Created `security-headers-grafana.conf` with appropriate CSP for Grafana
- Updated `default.conf` and `default.prod.conf` to use Grafana-specific headers

## CSP Policy
```
default-src 'self'; 
script-src 'self' 'unsafe-inline' 'unsafe-eval'; 
style-src 'self' 'unsafe-inline'; 
img-src 'self' data: https:; 
font-src 'self' data:; 
connect-src 'self' ws: wss:;
```

## Test Plan
- [x] Grafana login page loads at `/grafana/`
- [x] Static CSS assets return 200 OK
- [x] Page title shows "Grafana" (not error message)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana security headers configuration to use Grafana-specific settings, improving the security posture of the deployment environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->