### PR TITLE
Fix Grafana proxy timeouts causing HTML truncation

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -300,6 +300,8 @@ services:
       # Grafana handles subpath (receives /grafana/ prefix, serves from subpath)
       - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-%(protocol)s://%(domain)s/grafana/}
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      # Extended timeout for large HTML responses with inline JSON (~63KB)
+      - GF_SERVER_REQUEST_TIMEOUT=120
     ports:
       - "${EXPOSE_GRAFANA_PORT:-3001}:3000"
     depends_on:

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -228,6 +228,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
+        # Extended timeouts for large Grafana HTML responses (~63KB with inline JSON)
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
+
         # Enable buffering for large JS/CSS bundles
         proxy_buffering on;
         proxy_buffer_size 128k;
@@ -254,6 +259,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Extended timeouts for WebSocket connections
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
     }
 
     #------------------------------

--- a/docker/nginx/conf.d/default.prod.conf
+++ b/docker/nginx/conf.d/default.prod.conf
@@ -239,6 +239,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
+        # Extended timeouts for large Grafana HTML responses (~63KB with inline JSON)
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
+
         # Enable buffering for large JS/CSS bundles
         proxy_buffering on;
         proxy_buffer_size 128k;
@@ -267,6 +272,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Extended timeouts for WebSocket connections
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
 
         error_page 502 503 504 = @maintenance;
     }


### PR DESCRIPTION
## Summary
- Fix Grafana HTML response (~63KB with inline JSON) timing out through nginx proxy
- Add proxy timeouts (120s) to nginx Grafana location blocks
- Add `GF_SERVER_REQUEST_TIMEOUT=120` for Grafana server-side timeout

## Root Cause Analysis
The Grafana index.html is ~63KB due to embedded JSON configuration. The default nginx `proxy_read_timeout` (60s) was causing the connection to timeout before the full HTML was received, resulting in truncated HTML missing the script tags at the end of the body. This caused the page to be stuck at "Loading Grafana".

## Changes
1. **Nginx timeouts** (both `default.conf` and `default.prod.conf`):
   - `proxy_read_timeout 120s`
   - `proxy_connect_timeout 120s`
   - `proxy_send_timeout 120s`
   - Applied to both `/grafana/` and `/grafana/api/live/` locations

2. **Grafana server-side timeout** (`docker-compose.yml`):
   - `GF_SERVER_REQUEST_TIMEOUT=120`

## Test Plan
- [x] Tested locally - full 63KB HTML loads with all 6 script tags
- [ ] Deploy to production and verify Grafana dashboard loads
- [ ] Verify login page appears (authentication still required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Grafana server and proxy timeout settings to 120 seconds for handling large requests and WebSocket connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->