### PR TITLE
Recover trust monitor overview policy on the client

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -160,7 +160,7 @@ httpx-sse==0.4.3
     # via
     #   langchain-community
     #   mcp
-huggingface-hub==1.7.1
+huggingface-hub==1.7.2
     # via
     #   datasets
     #   tokenizers

--- a/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
+++ b/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
@@ -234,4 +234,23 @@ describe("TrustMonitoringCard", () => {
       screen.getByText("Policy state is loading. The browser will retry if the server bootstrap missed it."),
     ).toBeInTheDocument();
   });
+
+  test("shows unavailable messaging when policy refresh failed", () => {
+    render(
+      <TrustMonitoringCard
+        policy={null}
+        isLoading={false}
+        isSaving={false}
+        error={"Could not load trust-monitor policy."}
+        onRetry={() => undefined}
+        onEnabledChange={() => undefined}
+        onDetectorToggle={() => undefined}
+        onAlertSurfaceChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Policy state could not be read.")).toBeInTheDocument();
+    expect(screen.getByText("Policy state is unavailable. Retry to fetch the latest policy.")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
+++ b/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
@@ -210,4 +210,28 @@ describe("TrustMonitoringCard", () => {
 
     expect(screen.getByText("Alert destination")).toBeInTheDocument();
   });
+
+  test("does not label missing policy state as off", () => {
+    render(
+      <TrustMonitoringCard
+        policy={null}
+        isLoading={true}
+        isSaving={false}
+        error={null}
+        onRetry={() => undefined}
+        onEnabledChange={() => undefined}
+        onDetectorToggle={() => undefined}
+        onAlertSurfaceChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Loading")).toBeInTheDocument();
+    expect(screen.queryByText("Off")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Policy state is still loading."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Policy state is loading. The browser will retry if the server bootstrap missed it."),
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/components/admin/overview/TrustMonitoringCard.tsx
+++ b/web/src/components/admin/overview/TrustMonitoringCard.tsx
@@ -70,7 +70,9 @@ export function TrustMonitoringCard({
   const showPromotionWarning = policy?.enabled && (policy.alert_surface === "staff_room" || policy.alert_surface === "both");
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   const trustMonitoringDescription = policy === null
-    ? "Policy state is loading. The browser will retry if the server bootstrap missed it."
+    ? (isLoading
+      ? "Policy state is loading. The browser will retry if the server bootstrap missed it."
+      : "Policy state is unavailable. Retry to fetch the latest policy.")
     : "Enable the shared detector pipeline for Matrix support rooms.";
 
   return (

--- a/web/src/components/admin/overview/TrustMonitoringCard.tsx
+++ b/web/src/components/admin/overview/TrustMonitoringCard.tsx
@@ -31,8 +31,16 @@ const TRUST_ALERT_SURFACES: readonly TrustAlertSurface[] = [
   "none",
 ];
 
-function rolloutState(policy: TrustMonitorPolicy | null): { label: string; description: string } {
-  if (!policy || !policy.enabled) {
+function rolloutState(
+  policy: TrustMonitorPolicy | null,
+  isLoading: boolean,
+): { label: string; description: string } {
+  if (!policy) {
+    return isLoading
+      ? { label: "Loading", description: "Policy state is still loading." }
+      : { label: "Unavailable", description: "Policy state could not be read." };
+  }
+  if (!policy.enabled) {
     return { label: "Off", description: "Detection is disabled." };
   }
   switch (policy.alert_surface) {
@@ -58,9 +66,12 @@ export function TrustMonitoringCard({
   onAlertSurfaceChange,
   defaultCollapsed = false,
 }: TrustMonitoringCardProps) {
-  const rollout = rolloutState(policy);
+  const rollout = rolloutState(policy, isLoading);
   const showPromotionWarning = policy?.enabled && (policy.alert_surface === "staff_room" || policy.alert_surface === "both");
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
+  const trustMonitoringDescription = policy === null
+    ? "Policy state is loading. The browser will retry if the server bootstrap missed it."
+    : "Enable the shared detector pipeline for Matrix support rooms.";
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -106,7 +117,7 @@ export function TrustMonitoringCard({
             <div className="flex items-center justify-between rounded-xl border border-border/70 bg-background/40 px-4 py-3">
               <div>
                 <div className="text-sm font-medium">Trust monitoring</div>
-                <div className="text-xs text-muted-foreground">Enable the shared detector pipeline for Matrix support rooms.</div>
+                <div className="text-xs text-muted-foreground">{trustMonitoringDescription}</div>
               </div>
               <Checkbox
                 checked={policy?.enabled ?? false}

--- a/web/src/hooks/useTrustMonitorPolicy.test.tsx
+++ b/web/src/hooks/useTrustMonitorPolicy.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { makeAuthenticatedRequest } from "@/lib/auth";
+import { useTrustMonitorPolicy } from "./useTrustMonitorPolicy";
+
+jest.mock("@/lib/auth", () => ({
+  makeAuthenticatedRequest: jest.fn(),
+}));
+
+const mockedMakeAuthenticatedRequest = makeAuthenticatedRequest as jest.MockedFunction<typeof makeAuthenticatedRequest>;
+
+function mockJsonResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  } as Response;
+}
+
+const POLICY = {
+  enabled: true,
+  name_collision_enabled: true,
+  silent_observer_enabled: true,
+  alert_surface: "admin_ui",
+  matrix_public_room_ids: ["!support:matrix.org"],
+  matrix_staff_room_id: "!staff:matrix.org",
+  silent_observer_window_days: 14,
+  early_read_window_seconds: 30,
+  minimum_observations: 10,
+  minimum_early_read_hits: 8,
+  read_to_reply_ratio_threshold: 12,
+  evidence_ttl_days: 7,
+  aggregate_ttl_days: 30,
+  finding_ttl_days: 30,
+  updated_at: "2026-03-20T10:00:00Z",
+} as const;
+
+describe("useTrustMonitorPolicy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("bootstraps client-side when initial policy is missing", async () => {
+    mockedMakeAuthenticatedRequest.mockResolvedValue(mockJsonResponse(POLICY));
+
+    const { result } = renderHook(() => useTrustMonitorPolicy(null));
+
+    await waitFor(() => expect(result.current.policy).toEqual(POLICY));
+    expect(mockedMakeAuthenticatedRequest).toHaveBeenCalledWith(
+      "/admin/security/trust-monitor/policy",
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("surfaces an error when bootstrap refresh fails", async () => {
+    mockedMakeAuthenticatedRequest.mockResolvedValue(mockJsonResponse({ detail: "nope" }, 503));
+
+    const { result } = renderHook(() => useTrustMonitorPolicy(null));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.policy).toBeNull();
+    expect(result.current.error).toBe("Could not load trust-monitor policy.");
+  });
+
+  test("updates policy optimistically and keeps server response", async () => {
+    mockedMakeAuthenticatedRequest.mockResolvedValueOnce(mockJsonResponse({
+      ...POLICY,
+      enabled: false,
+    }));
+
+    const { result } = renderHook(() => useTrustMonitorPolicy(POLICY));
+
+    await act(async () => {
+      await result.current.setEnabled(false);
+    });
+
+    expect(mockedMakeAuthenticatedRequest).toHaveBeenCalledWith(
+      "/admin/security/trust-monitor/policy",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ enabled: false }),
+      }),
+    );
+    expect(result.current.policy?.enabled).toBe(false);
+  });
+});

--- a/web/src/hooks/useTrustMonitorPolicy.ts
+++ b/web/src/hooks/useTrustMonitorPolicy.ts
@@ -43,6 +43,13 @@ export function useTrustMonitorPolicy(initialPolicy: TrustMonitorPolicy | null) 
     }
   }, []);
 
+  useEffect(() => {
+    if (initialPolicy !== null) {
+      return;
+    }
+    void refresh();
+  }, [initialPolicy, refresh]);
+
   const updatePolicy = useCallback(async (patch: TrustMonitorPolicyPatch) => {
     if (Object.keys(patch).length === 0) {
       return true;


### PR DESCRIPTION
## Summary
- retry the trust monitor policy fetch in the browser when the overview SSR bootstrap misses it
- stop rendering a missing policy state as "Off" in the overview card
- add focused hook and component regression coverage

## Testing
- cd web && npm run lint
- cd web && npm run test -- --runInBand --runTestsByPath src/hooks/useTrustMonitorPolicy.test.tsx src/components/admin/overview/TrustMonitoringCard.test.tsx src/components/admin/overview/OverviewClient.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trust Monitoring now shows "Loading" while fetching the policy and distinguishes unavailable vs loading states.
  * Trust Monitoring settings are automatically loaded on startup when no policy is present.

* **Tests**
  * Added comprehensive tests covering Trust Monitoring UI states and policy load/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->