### PR TITLE
Fix training pipeline extraction bugs and upgrade to gpt-4.1-nano

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -170,7 +170,7 @@ class Settings(BaseSettings):
     # OpenAI settings (using AISuite for LLM interface)
     OPENAI_API_KEY: str = ""
     OPENAI_EMBEDDING_MODEL: str = "text-embedding-3-small"
-    OPENAI_MODEL: str = "openai:gpt-4o-mini"  # Full model ID with provider prefix
+    OPENAI_MODEL: str = "openai:gpt-4.1-nano"  # Full model ID with provider prefix
     MAX_TOKENS: int = 4096
     LLM_TEMPERATURE: float = 0.7  # Temperature for LLM responses (0.0-2.0)
 
@@ -184,9 +184,9 @@ class Settings(BaseSettings):
     VOYAGE_API_KEY: str = ""  # API key for Voyage embeddings
 
     # Token pricing (for cost tracking in metrics)
-    # Default values are for GPT-4o-mini as of 2024
-    OPENAI_INPUT_COST_PER_TOKEN: float = 0.00000015  # $0.15 per 1M tokens
-    OPENAI_OUTPUT_COST_PER_TOKEN: float = 0.0000006  # $0.60 per 1M tokens
+    # Default values are for GPT-4.1-nano
+    OPENAI_INPUT_COST_PER_TOKEN: float = 0.0000001  # $0.10 per 1M tokens
+    OPENAI_OUTPUT_COST_PER_TOKEN: float = 0.0000004  # $0.40 per 1M tokens
 
     # RAG settings
     MAX_CHAT_HISTORY_LENGTH: int = (
@@ -303,12 +303,12 @@ class Settings(BaseSettings):
         description="Enable full LLM extraction (replaces pattern-based)",
     )
     LLM_EXTRACTION_MODEL: str = Field(
-        default="openai:gpt-4o-mini",
+        default="openai:gpt-4.1-nano",
         description="Model for extraction (format: 'provider:model')",
     )
     LLM_EXTRACTION_BATCH_SIZE: int = Field(
         default=2000,
-        description="Maximum number of messages to process in a single LLM batch (gpt-4o-mini supports ~128K tokens)",
+        description="Maximum number of messages to process in a single LLM batch",
     )
     LLM_EXTRACTION_CACHE_TTL: int = Field(
         default=3600,

--- a/api/app/services/training/unified_faq_extractor.py
+++ b/api/app/services/training/unified_faq_extractor.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import logging
 import random
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -95,6 +96,8 @@ Your task is to extract HIGH-QUALITY FAQ pairs where:
 - Staff-to-staff discussions
 - Unclear or context-dependent exchanges
 - Messages that are only confirmations or agreements
+- Staff messages that have no preceding user question in the transcript
+- Cases where only a staff member is speaking (no user question exists)
 
 ### Handling corrections:
 If a staff member corrects their own answer:
@@ -222,7 +225,15 @@ Return a JSON object with this structure:
   ]
 }
 
-CRITICAL: Both `original_question_text` and `original_answer_text` MUST contain EXACT VERBATIM text:
+CRITICAL MESSAGE ID RULES:
+- `question_msg_id` and `answer_msg_id` MUST be DIFFERENT message IDs
+- `question_msg_id` MUST point to a USER message (User_N), NEVER a staff message
+- `answer_msg_id` MUST point to a STAFF message (Staff_N), NEVER a user message
+- Copy the EXACT ID string from the "(ID: ...)" field in the transcript — do NOT invent, abbreviate, or fabricate IDs
+- If you cannot find a valid user question message for a staff answer, SKIP the pair entirely
+- If you cannot find two distinct messages (one user, one staff), SKIP the pair entirely
+
+CRITICAL VERBATIM TEXT RULES:
 - `original_question_text`: Copy the user's question word-for-word from the message matching question_msg_id
 - `original_answer_text`: Copy the staff's answer word-for-word from the message matching answer_msg_id
 - Include informal language, typos, and original style - NO modifications
@@ -249,6 +260,59 @@ Confidence scoring (considers both extraction quality AND transformation quality
 
 Only include pairs with confidence >= 0.7 for FAQ training data quality.
 """
+
+# Pre-compiled patterns for detecting LLM-fabricated message IDs
+_FABRICATED_ID_PATTERNS = (
+    re.compile(r"\$\d+"),  # "$3", "$50" — fake Matrix event IDs
+    re.compile(r"Msg\s*#?\d+", re.IGNORECASE),  # "Msg #2" — transcript numbering
+    re.compile(r"msg\d+", re.IGNORECASE),  # "msg88" — abbreviated numbering
+)
+
+# Strict JSON schema for OpenAI structured outputs.
+# Guarantees well-formed responses and reduces message ID fabrication.
+_FAQ_EXTRACTION_JSON_SCHEMA: Dict[str, Any] = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "faq_extraction",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "faq_pairs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question_text": {"type": "string"},
+                            "answer_text": {"type": "string"},
+                            "original_question_text": {"type": "string"},
+                            "original_answer_text": {"type": "string"},
+                            "question_msg_id": {"type": "string"},
+                            "answer_msg_id": {"type": "string"},
+                            "confidence": {"type": "number"},
+                            "has_correction": {"type": "boolean"},
+                            "category": {"type": "string"},
+                        },
+                        "required": [
+                            "question_text",
+                            "answer_text",
+                            "original_question_text",
+                            "original_answer_text",
+                            "question_msg_id",
+                            "answer_msg_id",
+                            "confidence",
+                            "has_correction",
+                            "category",
+                        ],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["faq_pairs"],
+            "additionalProperties": False,
+        },
+    },
+}
 
 
 @dataclass
@@ -306,28 +370,55 @@ class FAQExtractionResult:
                 if text:
                     msg_text_map[msg_id] = text
 
-        return [
-            {
-                "question_text": faq.question_text,
-                "staff_answer": faq.answer_text,
-                "source_event_id": faq.answer_msg_id,
-                "source": self.source,
-                "confidence": faq.confidence,
-                "has_correction": faq.has_correction,
-                # Lookup staff_sender from original message author
-                "staff_sender": msg_author_map.get(faq.answer_msg_id, ""),
-                "category": faq.category,
-                # Original user question: prefer direct lookup, fall back to LLM's copy
-                "original_user_question": msg_text_map.get(
-                    faq.question_msg_id, faq.original_question_text
-                ),
-                # Original staff answer: prefer direct lookup, fall back to LLM's copy
-                "original_staff_answer": msg_text_map.get(
-                    faq.answer_msg_id, faq.original_answer_text
-                ),
-            }
-            for faq in self.faqs
-        ]
+        results = []
+        for faq in self.faqs:
+            question_author = msg_author_map.get(faq.question_msg_id, "")
+            answer_author = msg_author_map.get(faq.answer_msg_id, "")
+
+            # Skip if both IDs resolve to the same author (same person)
+            if question_author and answer_author and question_author == answer_author:
+                logger.warning(
+                    "Skipping FAQ: question and answer from same author '%s' "
+                    "(event %s).",
+                    answer_author,
+                    faq.answer_msg_id,
+                )
+                continue
+
+            orig_question = msg_text_map.get(
+                faq.question_msg_id, faq.original_question_text
+            )
+            orig_answer = msg_text_map.get(faq.answer_msg_id, faq.original_answer_text)
+
+            # Skip if original question and answer are identical text
+            if (
+                orig_question
+                and orig_answer
+                and orig_question.strip() == orig_answer.strip()
+            ):
+                logger.warning(
+                    "Skipping FAQ: original_user_question identical to "
+                    "original_staff_answer (event %s). Likely same message "
+                    "used for both.",
+                    faq.answer_msg_id,
+                )
+                continue
+
+            results.append(
+                {
+                    "question_text": faq.question_text,
+                    "staff_answer": faq.answer_text,
+                    "source_event_id": faq.answer_msg_id,
+                    "source": self.source,
+                    "confidence": faq.confidence,
+                    "has_correction": faq.has_correction,
+                    "staff_sender": answer_author,
+                    "category": faq.category,
+                    "original_user_question": orig_question,
+                    "original_staff_answer": orig_answer,
+                }
+            )
+        return results
 
 
 class UnifiedFAQExtractor:
@@ -364,6 +455,20 @@ class UnifiedFAQExtractor:
         self.settings = settings
         self.staff_identifiers = staff_identifiers or DEFAULT_STAFF_IDENTIFIERS
 
+    def _is_staff_author(self, author: str) -> bool:
+        """Check if author matches any staff identifier.
+
+        Handles Matrix IDs (@user:server), Bisq2 usernames, and partial
+        matches against the local-part of Matrix-style identifiers.
+        """
+        author_lower = author.lower().lstrip("@")
+        # For Matrix IDs like "user:server", extract just the local part
+        author_local = author_lower.split(":")[0]
+        return any(
+            staff_id.lower().lstrip("@").split(":")[0] == author_local
+            for staff_id in self.staff_identifiers
+        )
+
     async def extract_faqs(
         self,
         messages: List[Dict[str, Any]],
@@ -391,8 +496,35 @@ class UnifiedFAQExtractor:
             )
 
         try:
-            # Normalize and anonymize messages
             normalized_messages = self._normalize_messages(messages, source)
+
+            # Without both user and staff messages, the LLM fabricates Q&A
+            # pairs by using staff messages as both question and answer.
+            has_staff = False
+            has_user = False
+            for msg in normalized_messages:
+                if self._is_staff_author(msg.get("author", "")):
+                    has_staff = True
+                else:
+                    has_user = True
+                if has_staff and has_user:
+                    break
+
+            if not has_staff or not has_user:
+                logger.info(
+                    "Skipping batch: missing %s messages (%d total). "
+                    "Need both user and staff messages for Q&A extraction.",
+                    "staff" if not has_staff else "user",
+                    len(normalized_messages),
+                )
+                return FAQExtractionResult(
+                    source=source,
+                    faqs=[],
+                    total_messages=len(messages),
+                    extracted_count=0,
+                    processing_time_ms=int((time.time() - start_time) * 1000),
+                )
+
             anonymized_text, username_mapping = self._anonymize_messages(
                 normalized_messages
             )
@@ -505,22 +637,7 @@ class UnifiedFAQExtractor:
             if author in user_mapping:
                 return user_mapping[author]
 
-            # Check if staff using exact or local-part matching
-            # Extract local part (before @) for Matrix-style identifiers
-            author_lower = author.lower()
-            author_local = author_lower.split("@")[0].lstrip("@")  # Handle @user:server
-
-            is_staff = any(
-                # Exact match (case-insensitive)
-                staff_id.lower() == author_lower
-                # Or local-part match for Matrix IDs like @user:matrix.org
-                or staff_id.lower() == author_local
-                # Or the staff ID is a local part that matches author's local part
-                or staff_id.lower().split("@")[0].lstrip("@") == author_local
-                for staff_id in self.staff_identifiers
-            )
-
-            if is_staff:
+            if self._is_staff_author(author):
                 anon = f"Staff_{staff_counter}"
                 staff_counter += 1
             else:
@@ -593,10 +710,13 @@ TRANSCRIPT:
 
 Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A pairs (confidence >= 0.7)."""
 
-        # Get model ID with provider prefix
         model_id = self.settings.OPENAI_MODEL
         if ":" not in model_id:
             model_id = f"openai:{model_id}"
+
+        extra_kwargs: Dict[str, Any] = {}
+        if model_id.startswith("openai:"):
+            extra_kwargs["response_format"] = _FAQ_EXTRACTION_JSON_SCHEMA
 
         for attempt in range(self.MAX_RETRIES):
             try:
@@ -612,6 +732,7 @@ Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A
                         ],
                         temperature=self.settings.LLM_TEMPERATURE,
                         max_tokens=min(4096, self.settings.MAX_TOKENS),
+                        **extra_kwargs,
                     ),
                 )
 
@@ -687,8 +808,27 @@ Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A
                 )
 
                 # Skip low-confidence or incomplete pairs
-                if faq.confidence >= 0.7 and faq.question_text and faq.answer_text:
-                    faqs.append(faq)
+                if faq.confidence < 0.7 or not faq.question_text or not faq.answer_text:
+                    continue
+
+                # Reject pairs where LLM returned same ID for question and answer
+                if faq.question_msg_id and faq.question_msg_id == faq.answer_msg_id:
+                    logger.warning(
+                        "Rejected FAQ: question_msg_id == answer_msg_id (%s). "
+                        "LLM confused user question with staff answer.",
+                        faq.question_msg_id,
+                    )
+                    continue
+
+                aid = faq.answer_msg_id
+                if aid and any(p.fullmatch(aid) for p in _FABRICATED_ID_PATTERNS):
+                    logger.warning(
+                        "Rejected FAQ: answer_msg_id '%s' looks fabricated.",
+                        aid,
+                    )
+                    continue
+
+                faqs.append(faq)
 
             except (KeyError, ValueError, TypeError) as e:
                 logger.warning(f"Failed to parse FAQ pair: {e}")

--- a/api/app/services/training/unified_faq_extractor.py
+++ b/api/app/services/training/unified_faq_extractor.py
@@ -724,9 +724,22 @@ TRANSCRIPT:
 
 Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A pairs (confidence >= 0.7)."""
 
-        model_id = self.settings.OPENAI_MODEL
+        model_id = (
+            getattr(self.settings, "LLM_EXTRACTION_MODEL", "")
+            or self.settings.OPENAI_MODEL
+        )
         if ":" not in model_id:
             model_id = f"openai:{model_id}"
+
+        temperature = getattr(
+            self.settings, "LLM_EXTRACTION_TEMPERATURE", self.settings.LLM_TEMPERATURE
+        )
+        max_tokens = min(
+            4096,
+            getattr(
+                self.settings, "LLM_EXTRACTION_MAX_TOKENS", self.settings.MAX_TOKENS
+            ),
+        )
 
         extra_kwargs: Dict[str, Any] = {}
         if model_id.startswith("openai:"):
@@ -734,7 +747,6 @@ Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                # AISuite is synchronous, run in executor to avoid blocking
                 loop = asyncio.get_running_loop()
                 response = await loop.run_in_executor(
                     None,
@@ -744,8 +756,8 @@ Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A
                             {"role": "system", "content": FAQ_EXTRACTION_SYSTEM_PROMPT},
                             {"role": "user", "content": user_prompt},
                         ],
-                        temperature=self.settings.LLM_TEMPERATURE,
-                        max_tokens=min(4096, self.settings.MAX_TOKENS),
+                        temperature=temperature,
+                        max_tokens=max_tokens,
                         **extra_kwargs,
                     ),
                 )

--- a/api/app/services/training/unified_faq_extractor.py
+++ b/api/app/services/training/unified_faq_extractor.py
@@ -458,16 +458,30 @@ class UnifiedFAQExtractor:
     def _is_staff_author(self, author: str) -> bool:
         """Check if author matches any staff identifier.
 
-        Handles Matrix IDs (@user:server), Bisq2 usernames, and partial
-        matches against the local-part of Matrix-style identifiers.
+        Matching rules (applied per staff_id):
+        1. Full-ID match when both sides have a homeserver
+           (@user:server == @user:server)
+        2. Localpart match when the staff_id is a bare username
+           ("suddenwhipvapor" matches @suddenwhipvapor:matrix.org)
         """
-        author_lower = author.lower().lstrip("@")
-        # For Matrix IDs like "user:server", extract just the local part
-        author_local = author_lower.split(":")[0]
-        return any(
-            staff_id.lower().lstrip("@").split(":")[0] == author_local
-            for staff_id in self.staff_identifiers
-        )
+        author_norm = author.lower().lstrip("@")
+        author_local = author_norm.split(":")[0]
+        author_has_server = ":" in author_norm
+
+        for sid in self.staff_identifiers:
+            sid_norm = sid.lower().lstrip("@")
+            sid_has_server = ":" in sid_norm
+
+            if sid_has_server and author_has_server:
+                # Both are full Matrix IDs — require exact match
+                if sid_norm == author_norm:
+                    return True
+            else:
+                # At least one is a bare username — compare localparts
+                if sid_norm.split(":")[0] == author_local:
+                    return True
+
+        return False
 
     async def extract_faqs(
         self,
@@ -820,12 +834,20 @@ Return a JSON object with the extracted FAQ pairs. Only include high-quality Q&A
                     )
                     continue
 
-                aid = faq.answer_msg_id
-                if aid and any(p.fullmatch(aid) for p in _FABRICATED_ID_PATTERNS):
-                    logger.warning(
-                        "Rejected FAQ: answer_msg_id '%s' looks fabricated.",
-                        aid,
-                    )
+                fabricated = False
+                for label, mid in (
+                    ("question_msg_id", faq.question_msg_id),
+                    ("answer_msg_id", faq.answer_msg_id),
+                ):
+                    if mid and any(p.fullmatch(mid) for p in _FABRICATED_ID_PATTERNS):
+                        logger.warning(
+                            "Rejected FAQ: %s '%s' looks fabricated.",
+                            label,
+                            mid,
+                        )
+                        fabricated = True
+                        break
+                if fabricated:
                     continue
 
                 faqs.append(faq)

--- a/api/app/services/training/unified_pipeline_service.py
+++ b/api/app/services/training/unified_pipeline_service.py
@@ -1724,6 +1724,23 @@ class UnifiedPipelineService:
                 skipped_reason="duplicate",
             )
 
+        # Skip if original question and answer are identical (LLM used same
+        # message for both — a known extraction bug)
+        if (
+            original_user_question
+            and original_staff_answer
+            and original_user_question.strip() == original_staff_answer.strip()
+        ):
+            return ProcessingResult(
+                candidate_id=None,
+                source=source,
+                source_event_id=source_event_id,
+                routing="SKIPPED",
+                final_score=0.0,
+                is_calibration_sample=False,
+                skipped_reason="identical_original_texts",
+            )
+
         # Skip if question or answer is too short
         if len(question_text.strip()) < 10 or len(staff_answer.strip()) < 10:
             return ProcessingResult(

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -160,7 +160,7 @@ httpx-sse==0.4.3
     # via
     #   langchain-community
     #   mcp
-huggingface-hub==1.9.2
+huggingface-hub==1.10.1
     # via
     #   datasets
     #   tokenizers
@@ -243,12 +243,12 @@ langgraph-prebuilt==1.0.9
     # via langgraph
 langgraph-sdk==0.3.13
     # via langgraph
-langsmith==0.7.29
+langsmith==0.7.30
     # via
     #   langchain-classic
     #   langchain-community
     #   langchain-core
-librt==0.8.1
+librt==0.9.0
     # via mypy
 litellm==1.80.0
     # via -r api/requirements.in
@@ -379,7 +379,7 @@ portalocker==3.2.0
     #   qdrant-client
 pre-commit==4.5.1
     # via -r api/requirements.in
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   -r api/requirements.in
     #   prometheus-fastapi-instrumentator
@@ -568,7 +568,7 @@ tqdm==4.67.3
     #   openai
     #   ragas
     #   transformers
-transformers==5.5.1
+transformers==5.5.3
     # via -r api/requirements.in
 typer==0.9.4
     # via
@@ -620,7 +620,7 @@ uvicorn==0.44.0
     # via
     #   -r api/requirements.in
     #   mcp
-virtualenv==21.2.0
+virtualenv==21.2.1
     # via pre-commit
 websockets==16.0
     # via -r api/requirements.in

--- a/api/tests/test_unified_faq_extractor.py
+++ b/api/tests/test_unified_faq_extractor.py
@@ -1188,3 +1188,308 @@ class TestOriginalAnswerPreservation:
         # simple_messages[0]["message"] = "How do I backup?"
         assert pipeline_data[0]["original_user_question"] == "How do I backup?"
         assert pipeline_data[0]["original_user_question"] != "WRONG QUESTION FROM LLM"
+
+
+# =============================================================================
+# PHASE 12: Duplicate Message ID and Identity Validation Tests
+# =============================================================================
+
+
+class TestDuplicateMessageIdRejection:
+    """Test that FAQs with identical question/answer message IDs are rejected."""
+
+    @pytest.fixture
+    def extractor(self, staff_identifiers):
+        mock_settings = MagicMock()
+        mock_settings.OPENAI_MODEL = "gpt-4o-mini"
+        mock_settings.LLM_TEMPERATURE = 0.1
+        mock_settings.MAX_TOKENS = 4096
+        return UnifiedFAQExtractor(
+            aisuite_client=MagicMock(),
+            settings=mock_settings,
+            staff_identifiers=staff_identifiers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_faq_with_same_question_and_answer_id(self, extractor):
+        """LLM returning same msg ID for question and answer should be filtered."""
+        messages = [
+            {
+                "messageId": "msg_staff1",
+                "message": "If the trade fails, open mediation.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+        ]
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "What to do if trade fails?",
+                    "answer_text": "Open mediation.",
+                    "question_msg_id": "msg_staff1",
+                    "answer_msg_id": "msg_staff1",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+
+        assert (
+            len(result.faqs) == 0
+        ), "FAQ with question_msg_id == answer_msg_id should be rejected"
+
+    @pytest.mark.asyncio
+    async def test_rejects_faq_with_fabricated_short_id(self, extractor):
+        """LLM returning short/numeric IDs instead of real event IDs should be filtered."""
+        messages = [
+            {
+                "messageId": "msg_q1",
+                "message": "How do I backup?",
+                "author": "user1",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+            {
+                "messageId": "msg_a1",
+                "message": "Go to Settings > Backup.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:01:00Z",
+                "citation": None,
+            },
+        ]
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "How do I backup?",
+                    "answer_text": "Go to Settings > Backup.",
+                    "question_msg_id": "$3",
+                    "answer_msg_id": "$7",  # Fabricated: "$" + digits only
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+
+        assert len(result.faqs) == 0, "FAQ with fabricated short IDs should be rejected"
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_faq_with_distinct_ids(self, extractor):
+        """Valid FAQ with different question and answer IDs should be accepted."""
+        messages = [
+            {
+                "messageId": "msg_q1",
+                "message": "How do I backup?",
+                "author": "user1",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+            {
+                "messageId": "msg_a1",
+                "message": "Go to Settings > Backup.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:01:00Z",
+                "citation": None,
+            },
+        ]
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "How do I backup?",
+                    "answer_text": "Go to Settings > Backup.",
+                    "question_msg_id": "msg_q1",
+                    "answer_msg_id": "msg_a1",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+
+        assert len(result.faqs) == 1
+
+
+class TestSameAuthorRejection:
+    """Test that FAQs where question and answer come from same person are filtered."""
+
+    @pytest.fixture
+    def extractor(self, staff_identifiers):
+        mock_settings = MagicMock()
+        mock_settings.OPENAI_MODEL = "gpt-4o-mini"
+        mock_settings.LLM_TEMPERATURE = 0.1
+        mock_settings.MAX_TOKENS = 4096
+        return UnifiedFAQExtractor(
+            aisuite_client=MagicMock(),
+            settings=mock_settings,
+            staff_identifiers=staff_identifiers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_faq_from_same_author(self, extractor):
+        """Both question and answer from same user should be filtered in pipeline format."""
+        messages = [
+            {
+                "messageId": "staff_msg_q1",
+                "message": "How do I backup?",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+            {
+                "messageId": "staff_msg_a1",
+                "message": "Go to Settings > Backup.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:01:00Z",
+                "citation": None,
+            },
+        ]
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "How do I backup?",
+                    "answer_text": "Go to Settings > Backup.",
+                    "question_msg_id": "staff_msg_q1",
+                    "answer_msg_id": "staff_msg_a1",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+
+        pipeline_items = result.to_pipeline_format()
+        assert (
+            len(pipeline_items) == 0
+        ), "FAQ where question and answer are from same author should be filtered"
+
+    @pytest.mark.asyncio
+    async def test_rejects_identical_original_texts_in_pipeline(self, extractor):
+        """If original_user_question == original_staff_answer, filter in pipeline format."""
+        messages = [
+            {
+                "messageId": "msg_staff",
+                "message": "Open mediation if trade fails.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+        ]
+        # LLM returns different IDs but one doesn't exist in the batch,
+        # so both fall back to same text
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "What if trade fails?",
+                    "answer_text": "Open mediation.",
+                    "question_msg_id": "nonexistent_q",
+                    "answer_msg_id": "nonexistent_a",
+                    "confidence": 0.9,
+                    "original_question_text": "Open mediation if trade fails.",
+                    "original_answer_text": "Open mediation if trade fails.",
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+
+        pipeline_items = result.to_pipeline_format()
+        assert (
+            len(pipeline_items) == 0
+        ), "FAQ with identical original question and answer text should be filtered"
+
+
+class TestPreBatchFiltering:
+    """Test that batches without both user and staff messages are skipped."""
+
+    @pytest.fixture
+    def extractor(self, staff_identifiers):
+        mock_settings = MagicMock()
+        mock_settings.OPENAI_MODEL = "openai:gpt-4.1-nano"
+        mock_settings.LLM_TEMPERATURE = 0.1
+        mock_settings.MAX_TOKENS = 4096
+        return UnifiedFAQExtractor(
+            aisuite_client=MagicMock(),
+            settings=mock_settings,
+            staff_identifiers=staff_identifiers,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_staff_only_batch(self, extractor):
+        """Batch with only staff messages should be skipped without LLM call."""
+        messages = [
+            {
+                "messageId": "s1",
+                "message": "Let me check the docs.",
+                "author": "suddenwhipvapor",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+            {
+                "messageId": "s2",
+                "message": "Found it, the limit is 600 USD.",
+                "author": "mwithm",
+                "date": "2026-01-15T10:01:00Z",
+                "citation": None,
+            },
+        ]
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+            mock.assert_not_called()
+
+        assert len(result.faqs) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_user_only_batch(self, extractor):
+        """Batch with only user messages should be skipped without LLM call."""
+        messages = [
+            {
+                "messageId": "u1",
+                "message": "How do I backup?",
+                "author": "someuser",
+                "date": "2026-01-15T10:00:00Z",
+                "citation": None,
+            },
+        ]
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            result = await extractor.extract_faqs(messages=messages, source="bisq2")
+            mock.assert_not_called()
+
+        assert len(result.faqs) == 0
+
+    @pytest.mark.asyncio
+    async def test_processes_mixed_batch(self, extractor, simple_qa_messages):
+        """Batch with both user and staff messages should be processed."""
+        mock_llm_response = {
+            "faq_pairs": [
+                {
+                    "question_text": "How do I start trading?",
+                    "answer_text": "Go to Trade Wizard.",
+                    "question_msg_id": "msg_q1",
+                    "answer_msg_id": "msg_a1",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        with patch.object(extractor, "_call_llm", new_callable=AsyncMock) as mock:
+            mock.return_value = mock_llm_response
+            result = await extractor.extract_faqs(
+                messages=simple_qa_messages, source="bisq2"
+            )
+            mock.assert_called_once()
+
+        assert len(result.faqs) == 1

--- a/api/tests/test_unified_faq_extractor.py
+++ b/api/tests/test_unified_faq_extractor.py
@@ -1215,6 +1215,13 @@ class TestDuplicateMessageIdRejection:
         """LLM returning same msg ID for question and answer should be filtered."""
         messages = [
             {
+                "messageId": "msg_user1",
+                "message": "What if my trade fails?",
+                "author": "user1",
+                "date": "2026-01-15T09:59:00Z",
+                "citation": None,
+            },
+            {
                 "messageId": "msg_staff1",
                 "message": "If the trade fails, open mediation.",
                 "author": "suddenwhipvapor",

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,8 +9,8 @@
 # OpenAI API key (required for LLM via AISuite)
 OPENAI_API_KEY=
 # Model ID with provider prefix for AISuite (format: "provider:model")
-# Examples: openai:gpt-4o-mini, openai:gpt-4o, anthropic:claude-3-5-sonnet
-OPENAI_MODEL=openai:gpt-4o-mini
+# Examples: openai:gpt-4.1-nano, openai:gpt-4.1-mini, openai:gpt-4o-mini
+OPENAI_MODEL=openai:gpt-4.1-nano
 MAX_TOKENS=4096
 # Temperature for LLM responses (0.0-2.0, default: 0.7)
 LLM_TEMPERATURE=0.7
@@ -197,12 +197,12 @@ PROMETHEUS_BASIC_AUTH_PASSWORD=prometheuspassword
 
 # Token cost tracking (for Prometheus metrics)
 # These values should match your configured OPENAI_MODEL pricing
-# Default values are for GPT-4o-mini (as of 2024):
-#   - Input: $0.15 per 1M tokens = $0.00000015 per token
-#   - Output: $0.60 per 1M tokens = $0.0000006 per token
+# Default values are for GPT-4.1-nano:
+#   - Input: $0.10 per 1M tokens = $0.0000001 per token
+#   - Output: $0.40 per 1M tokens = $0.0000004 per token
 # For other models, see: https://openai.com/api/pricing/
-OPENAI_INPUT_COST_PER_TOKEN=0.00000015
-OPENAI_OUTPUT_COST_PER_TOKEN=0.0000006
+OPENAI_INPUT_COST_PER_TOKEN=0.0000001
+OPENAI_OUTPUT_COST_PER_TOKEN=0.0000004
 
 # External health monitoring (Healthchecks.io)
 # Sign up at https://healthchecks.io and create a check with:
@@ -259,9 +259,9 @@ MATRIX_ALERT_SESSION_FILE=/data/matrix_alert_session.json
 ENABLE_LLM_EXTRACTION=false
 
 # LLM model for question extraction (format: "provider:model")
-# Recommended: openai:gpt-4o-mini for cost efficiency
-# Alternative: openai:gpt-4o for higher accuracy (more expensive)
-LLM_EXTRACTION_MODEL=openai:gpt-4o-mini
+# Recommended: openai:gpt-4.1-nano for cost efficiency
+# Alternative: openai:gpt-4.1-mini for higher accuracy
+LLM_EXTRACTION_MODEL=openai:gpt-4.1-nano
 
 # Number of conversations to process in parallel batches
 # Higher values = faster processing but more API rate limit pressure


### PR DESCRIPTION
## Summary
- **Problem**: 36 of 309 training candidates (11.7%) had identical `original_user_question` and `original_staff_answer`. Root cause: LLM returned the same message ID for both question and answer fields, or fabricated IDs from transcript numbering.
- **Fix**: 5 layers of defense — prompt hardening, duplicate ID rejection, fabricated ID detection, same-author rejection, identical-text guard. Plus pre-batch filtering and strict JSON schema mode.
- **Model upgrade**: gpt-4o-mini to gpt-4.1-nano (33% cheaper, 2.4x faster response times, better instruction following).

## Changes
- `api/app/services/training/unified_faq_extractor.py`: Prompt hardening, `_is_staff_author()` helper, pre-batch filter, strict JSON schema, validation guards in `_parse_llm_response` and `to_pipeline_format`, pre-compiled regex patterns
- `api/app/services/training/unified_pipeline_service.py`: Belt-and-suspenders identical-text guard in `_process_extracted_faq`
- `api/app/core/config.py`: Model defaults gpt-4o-mini -> gpt-4.1-nano, updated token pricing
- `docker/.env.example`: Updated model and pricing defaults
- `api/tests/test_unified_faq_extractor.py`: 8 new tests (TestDuplicateMessageIdRejection, TestSameAuthorRejection, TestPreBatchFiltering)

## Test plan
- [x] 34 extractor tests pass (8 new)
- [x] 2657 full API tests pass
- [x] Manual extraction test with gpt-4.1-nano + strict JSON schema on production
- [x] A/B model comparison: nano is 2.4x faster, same quality, 33% cheaper
- [x] Docker image builds successfully
- [x] 36 affected production candidates already cleaned up (rejected with `auto_cleanup`)
- [ ] Deploy and verify new extractions produce valid distinct IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced FAQ extraction with stricter validation and automatic filtering of duplicate/identical Q&A pairs.

* **Bug Fixes**
  * Improved detection and rejection of invalid or fabricated message references and malformed batch data.
  * Early skipping of identical original question/answer pairs to avoid false positives.

* **Tests**
  * Expanded test coverage for FAQ validation, duplicate-ID rejection, same-author filtering, and pre-batch checks.

* **Chores**
  * Updated default LLM model and example token-cost defaults; bumped several dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->