### PR TITLE
Add proactive impersonation detection and fix escalation close bug

### DIFF
--- a/api/app/channels/trust_monitor/proactive_scanner.py
+++ b/api/app/channels/trust_monitor/proactive_scanner.py
@@ -25,6 +25,14 @@ from app.channels.trust_monitor.detectors.staff_name_collision import (
 )
 from app.channels.trust_monitor.models import TrustAlertSurface
 
+try:
+    from nio import RoomSendResponse
+
+    _NIO_AVAILABLE = True
+except ImportError:
+    _NIO_AVAILABLE = False
+    RoomSendResponse = None
+
 logger = logging.getLogger(__name__)
 
 # Bisq-related keywords for public room scanning
@@ -107,12 +115,17 @@ class ProactiveImpersonationScanner:
         logger.info("Proactive impersonation scanner stopped")
 
     async def _scan_loop(self) -> None:
+        logger.info("Proactive scanner waiting 30s before first scan...")
         await asyncio.sleep(30)
         while self._running:
             try:
                 await self._run_scans()
             except Exception:
-                logger.warning("Proactive scan failed", exc_info=True)
+                logger.warning(
+                    "Proactive scan cycle failed (interval=%ds)",
+                    self.scan_interval_seconds,
+                    exc_info=True,
+                )
             try:
                 await asyncio.sleep(self.scan_interval_seconds)
             except asyncio.CancelledError:
@@ -291,7 +304,7 @@ class ProactiveImpersonationScanner:
 
     async def _post_scam_warning(self) -> None:
         """Post a scam warning in monitored rooms (max once per 24h per room)."""
-        if self.matrix_client is None:
+        if self.matrix_client is None or not _NIO_AVAILABLE:
             return
 
         now = datetime.now(UTC)
@@ -301,8 +314,6 @@ class ProactiveImpersonationScanner:
                 continue
 
             try:
-                from nio import RoomSendResponse
-
                 resp = await self.matrix_client.room_send(
                     room_id=room_id,
                     message_type="m.room.message",

--- a/api/app/channels/trust_monitor/proactive_scanner.py
+++ b/api/app/channels/trust_monitor/proactive_scanner.py
@@ -1,0 +1,321 @@
+"""Proactive impersonation scanner for Matrix.
+
+Periodically searches the Matrix user directory and public room directory
+for potential impersonation of Bisq staff. Creates trust findings when
+suspicious accounts or rooms are discovered.
+
+Capabilities:
+1. User directory scan — finds accounts with display names matching staff
+2. Public room directory scan — finds rooms with Bisq-related names
+3. Educational warning — posts scam warnings when name collisions are found
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import aiohttp
+from app.channels.staff import StaffResolver
+from app.channels.trust_monitor.detectors.base import DetectorResult
+from app.channels.trust_monitor.detectors.staff_name_collision import (
+    normalize_display_name,
+)
+from app.channels.trust_monitor.models import TrustAlertSurface
+
+logger = logging.getLogger(__name__)
+
+# Bisq-related keywords for public room scanning
+_BISQ_ROOM_KEYWORDS = [
+    "bisq",
+    "bisq support",
+    "bisq help",
+    "bisq easy",
+    "bisq2",
+    "bisq 2",
+]
+
+# Subset used for the "suspicious room name" filter
+_SUSPICIOUS_ROOM_TERMS = ["bisq support", "bisq help", "bisq easy"]
+
+_SCAM_WARNING = (
+    "\u26a0\ufe0f **Security Notice**: Official Bisq support staff will **NEVER** send "
+    "you a direct message first. If someone DMs you claiming to be Bisq support, "
+    "**do not share your seed phrase, passwords, or send any funds**. "
+    "Report suspicious accounts to the room moderators."
+)
+
+# Minimum interval between scam warnings per room (24 hours)
+_WARNING_COOLDOWN = timedelta(hours=24)
+
+
+class ProactiveImpersonationScanner:
+    """Periodic scanner for Matrix impersonation attempts."""
+
+    DETECTOR_KEY_USER = "proactive_user_impersonation"
+    DETECTOR_KEY_ROOM = "proactive_fake_room"
+
+    def __init__(
+        self,
+        *,
+        homeserver_url: str,
+        access_token: str,
+        staff_resolver: StaffResolver,
+        trusted_staff_ids: set[str],
+        monitored_room_ids: set[str],
+        official_room_ids: set[str] | None = None,
+        matrix_client: Any | None = None,
+        scan_interval_seconds: int = 900,
+        on_finding: Any | None = None,
+    ) -> None:
+        self.homeserver_url = homeserver_url.rstrip("/")
+        self.access_token = access_token
+        self.staff_resolver = staff_resolver
+        self.trusted_staff_ids = {sid.lower() for sid in trusted_staff_ids}
+        self.monitored_room_ids = monitored_room_ids
+        self.official_room_ids = (official_room_ids or set()) | set(monitored_room_ids)
+        self.matrix_client = matrix_client
+        self.scan_interval_seconds = scan_interval_seconds
+        self.on_finding = on_finding
+        self._task: asyncio.Task[Any] | None = None
+        self._running = False
+        self._reported_user_ids: set[str] = set()
+        self._reported_room_ids: set[str] = set()
+        self._last_warning_per_room: dict[str, datetime] = {}
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._scan_loop())
+        logger.info(
+            "Proactive impersonation scanner started (interval=%ds)",
+            self.scan_interval_seconds,
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Proactive impersonation scanner stopped")
+
+    async def _scan_loop(self) -> None:
+        await asyncio.sleep(30)
+        while self._running:
+            try:
+                await self._run_scans()
+            except Exception:
+                logger.warning("Proactive scan failed", exc_info=True)
+            try:
+                await asyncio.sleep(self.scan_interval_seconds)
+            except asyncio.CancelledError:
+                break
+
+    async def _run_scans(self) -> None:
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        timeout = aiohttp.ClientTimeout(total=15)
+
+        async with aiohttp.ClientSession(headers=headers, timeout=timeout) as session:
+            user_findings, room_findings = await asyncio.gather(
+                self._scan_user_directory(session),
+                self._scan_public_rooms(session),
+            )
+
+        for finding in user_findings + room_findings:
+            if self.on_finding is not None:
+                try:
+                    self.on_finding(finding)
+                except Exception:
+                    logger.warning("on_finding callback failed", exc_info=True)
+
+        if user_findings:
+            await self._post_scam_warning()
+
+    # ------------------------------------------------------------------
+    # User directory scanning
+    # ------------------------------------------------------------------
+
+    async def _scan_user_directory(
+        self, session: aiohttp.ClientSession
+    ) -> list[DetectorResult]:
+        """Search Matrix user directory for display names matching staff."""
+        staff_names = self.staff_resolver.get_display_names()
+        if not staff_names:
+            return []
+
+        findings: list[DetectorResult] = []
+
+        for name in staff_names:
+            normalized_staff = normalize_display_name(name)
+            try:
+                resp = await session.post(
+                    f"{self.homeserver_url}/_matrix/client/v3/user_directory/search",
+                    json={"search_term": name, "limit": 20},
+                )
+                if resp.status != 200:
+                    continue
+
+                data = await resp.json()
+
+                for user in data.get("results", []):
+                    user_id = str(user.get("user_id", "")).strip()
+                    display_name = str(user.get("display_name", "")).strip()
+
+                    if not user_id or not display_name:
+                        continue
+                    if user_id.lower() in self.trusted_staff_ids:
+                        continue
+                    if user_id in self._reported_user_ids:
+                        continue
+                    if normalize_display_name(display_name) != normalized_staff:
+                        continue
+
+                    logger.warning(
+                        "Proactive scan: potential impersonator '%s' (%s) "
+                        "matches staff name '%s'",
+                        display_name,
+                        user_id,
+                        name,
+                    )
+                    self._reported_user_ids.add(user_id)
+                    findings.append(
+                        DetectorResult(
+                            detector_key=self.DETECTOR_KEY_USER,
+                            suspect_actor_id=user_id,
+                            suspect_actor_key=user_id,
+                            suspect_display_name=display_name,
+                            score=0.95,
+                            evidence_summary={
+                                "matched_staff_name": name,
+                                "user_id": user_id,
+                                "display_name": display_name,
+                                "detection_method": "user_directory_search",
+                            },
+                            alert_surface=TrustAlertSurface.BOTH,
+                            occurred_at=datetime.now(UTC),
+                        )
+                    )
+            except Exception:
+                logger.debug(
+                    "User directory search error for '%s'", name, exc_info=True
+                )
+
+        if findings:
+            logger.info(
+                "Proactive user scan found %d potential impersonator(s)",
+                len(findings),
+            )
+        return findings
+
+    # ------------------------------------------------------------------
+    # Public room directory scanning
+    # ------------------------------------------------------------------
+
+    async def _scan_public_rooms(
+        self, session: aiohttp.ClientSession
+    ) -> list[DetectorResult]:
+        """Search Matrix public room directory for Bisq-related rooms."""
+        findings: list[DetectorResult] = []
+
+        for keyword in _BISQ_ROOM_KEYWORDS:
+            try:
+                resp = await session.post(
+                    f"{self.homeserver_url}/_matrix/client/v3/publicRooms",
+                    json={"filter": {"generic_search_term": keyword}, "limit": 50},
+                )
+                if resp.status != 200:
+                    continue
+
+                data = await resp.json()
+
+                for room in data.get("chunk", []):
+                    room_id = str(room.get("room_id", "")).strip()
+                    room_name = str(room.get("name", "")).strip()
+
+                    if not room_id:
+                        continue
+                    if room_id in self.official_room_ids:
+                        continue
+                    if room_id in self._reported_room_ids:
+                        continue
+
+                    name_lower = room_name.lower()
+                    if not any(term in name_lower for term in _SUSPICIOUS_ROOM_TERMS):
+                        continue
+
+                    logger.warning(
+                        "Proactive scan: suspicious room '%s' (%s)",
+                        room_name,
+                        room_id,
+                    )
+                    self._reported_room_ids.add(room_id)
+                    findings.append(
+                        DetectorResult(
+                            detector_key=self.DETECTOR_KEY_ROOM,
+                            suspect_actor_id=room_id,
+                            suspect_actor_key=room_id,
+                            suspect_display_name=room_name,
+                            score=0.80,
+                            evidence_summary={
+                                "room_id": room_id,
+                                "room_name": room_name,
+                                "matched_keyword": keyword,
+                                "num_joined_members": room.get("num_joined_members", 0),
+                                "detection_method": "public_room_directory_search",
+                            },
+                            alert_surface=TrustAlertSurface.BOTH,
+                            occurred_at=datetime.now(UTC),
+                        )
+                    )
+            except Exception:
+                logger.debug(
+                    "Public room search error for '%s'", keyword, exc_info=True
+                )
+
+        if findings:
+            logger.info(
+                "Proactive room scan found %d suspicious room(s)", len(findings)
+            )
+        return findings
+
+    # ------------------------------------------------------------------
+    # Educational warning (rate-limited per room)
+    # ------------------------------------------------------------------
+
+    async def _post_scam_warning(self) -> None:
+        """Post a scam warning in monitored rooms (max once per 24h per room)."""
+        if self.matrix_client is None:
+            return
+
+        now = datetime.now(UTC)
+        for room_id in self.monitored_room_ids:
+            last = self._last_warning_per_room.get(room_id)
+            if last is not None and (now - last) < _WARNING_COOLDOWN:
+                continue
+
+            try:
+                from nio import RoomSendResponse
+
+                resp = await self.matrix_client.room_send(
+                    room_id=room_id,
+                    message_type="m.room.message",
+                    content={"msgtype": "m.notice", "body": _SCAM_WARNING},
+                )
+                if isinstance(resp, RoomSendResponse):
+                    self._last_warning_per_room[room_id] = now
+                    logger.info("Posted scam warning to %s", room_id)
+                else:
+                    logger.warning(
+                        "Failed to post scam warning to %s: %s", room_id, resp
+                    )
+            except Exception:
+                logger.warning(
+                    "Error posting scam warning to %s", room_id, exc_info=True
+                )

--- a/api/app/channels/trust_monitor/proactive_scanner.py
+++ b/api/app/channels/trust_monitor/proactive_scanner.py
@@ -165,12 +165,15 @@ class ProactiveImpersonationScanner:
 
         findings: list[DetectorResult] = []
 
+        per_request_timeout = aiohttp.ClientTimeout(total=10)
+
         for name in staff_names:
             normalized_staff = normalize_display_name(name)
             try:
                 resp = await session.post(
                     f"{self.homeserver_url}/_matrix/client/v3/user_directory/search",
                     json={"search_term": name, "limit": 20},
+                    timeout=per_request_timeout,
                 )
                 if resp.status != 200:
                     continue
@@ -215,6 +218,12 @@ class ProactiveImpersonationScanner:
                             occurred_at=datetime.now(UTC),
                         )
                     )
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                logger.debug(
+                    "User directory search timed out or failed for '%s'",
+                    name,
+                    exc_info=True,
+                )
             except Exception:
                 logger.debug(
                     "User directory search error for '%s'", name, exc_info=True
@@ -237,11 +246,14 @@ class ProactiveImpersonationScanner:
         """Search Matrix public room directory for Bisq-related rooms."""
         findings: list[DetectorResult] = []
 
+        per_request_timeout = aiohttp.ClientTimeout(total=10)
+
         for keyword in _BISQ_ROOM_KEYWORDS:
             try:
                 resp = await session.post(
                     f"{self.homeserver_url}/_matrix/client/v3/publicRooms",
                     json={"filter": {"generic_search_term": keyword}, "limit": 50},
+                    timeout=per_request_timeout,
                 )
                 if resp.status != 200:
                     continue
@@ -287,6 +299,12 @@ class ProactiveImpersonationScanner:
                             occurred_at=datetime.now(UTC),
                         )
                     )
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                logger.debug(
+                    "Public room search timed out or failed for '%s'",
+                    keyword,
+                    exc_info=True,
+                )
             except Exception:
                 logger.debug(
                     "Public room search error for '%s'", keyword, exc_info=True

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -560,7 +560,12 @@ async def lifespan(app: FastAPI):
                     if trust_monitor_service.publisher:
                         trust_monitor_service.publisher.publish(finding)
                 except Exception:
-                    logger.warning("Failed to persist proactive finding", exc_info=True)
+                    logger.warning(
+                        "Failed to persist proactive finding for %s (%s)",
+                        result.suspect_actor_id,
+                        result.detector_key,
+                        exc_info=True,
+                    )
 
             scanner = ProactiveImpersonationScanner(
                 homeserver_url=settings.MATRIX_HOMESERVER_URL,

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -519,6 +519,66 @@ async def lifespan(app: FastAPI):
     app.state.bisq2_live_chat_service = app.state.channel_polling_services.get("bisq2")
     app.state.matrix_channel = bootstrap_result.registry.get("matrix")
 
+    # Start proactive impersonation scanner (user directory + public room scans)
+    app.state.proactive_scanner = None
+    trust_monitor_service = getattr(app.state, "trust_monitor_service", None)
+    matrix_channel = bootstrap_result.registry.get("matrix")
+    if trust_monitor_service is not None and matrix_channel is not None:
+        matrix_runtime = getattr(matrix_channel, "runtime", None)
+        matrix_client = (
+            matrix_runtime.resolve_optional("matrix_client")
+            if matrix_runtime is not None
+            else None
+        )
+        if matrix_client is not None and getattr(matrix_client, "access_token", None):
+            from app.channels.plugins.matrix.room_filter import (
+                resolve_allowed_sync_rooms,
+            )
+            from app.channels.trust_monitor.proactive_scanner import (
+                ProactiveImpersonationScanner,
+            )
+
+            sync_rooms = resolve_allowed_sync_rooms(settings)
+
+            def _handle_proactive_finding(result):
+                """Persist finding via trust monitor store and publish alert."""
+                try:
+                    space_id = next(iter(sync_rooms), "proactive_scan")
+                    finding = trust_monitor_service.store.upsert_finding(
+                        detector_key=result.detector_key,
+                        channel_id="matrix",
+                        space_id=space_id,
+                        suspect_actor_key=result.suspect_actor_key,
+                        suspect_actor_id=result.suspect_actor_id,
+                        suspect_display_name=result.suspect_display_name,
+                        score=result.score,
+                        alert_surface=result.alert_surface,
+                        evidence_summary=result.evidence_summary,
+                        created_at=result.occurred_at,
+                        notify=True,
+                    )
+                    if trust_monitor_service.publisher:
+                        trust_monitor_service.publisher.publish(finding)
+                except Exception:
+                    logger.warning("Failed to persist proactive finding", exc_info=True)
+
+            scanner = ProactiveImpersonationScanner(
+                homeserver_url=settings.MATRIX_HOMESERVER_URL,
+                access_token=matrix_client.access_token,
+                staff_resolver=trust_monitor_service.staff_resolver,
+                trusted_staff_ids=set(
+                    collect_trusted_staff_ids(settings, channel_id="matrix")
+                ),
+                monitored_room_ids=set(sync_rooms),
+                matrix_client=matrix_client,
+                on_finding=_handle_proactive_finding,
+            )
+            await scanner.start()
+            app.state.proactive_scanner = scanner
+            logger.info("Proactive impersonation scanner started")
+        else:
+            logger.info("Proactive scanner not started (Matrix client not connected)")
+
     # Initialize Tor metrics
     logger.info("Initializing Tor metrics...")
     tor_configured = bool(settings.TOR_HIDDEN_SERVICE)
@@ -610,6 +670,11 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             # P5: Log error but don't crash shutdown
             logger.error(f"Failed to save LearningEngine state during shutdown: {e}")
+
+    # Stop proactive impersonation scanner
+    scanner = getattr(app.state, "proactive_scanner", None)
+    if scanner is not None:
+        await scanner.stop()
 
     # Stop Tor monitoring service
     if hasattr(app.state, "tor_monitoring_service"):

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -49,7 +49,7 @@ beautifulsoup4==4.14.3
     # via -r api/requirements.in
 black==26.3.1
     # via -r api/requirements.in
-build==1.4.2
+build==1.4.3
     # via pip-tools
 cachetools==5.5.2
     # via
@@ -185,7 +185,7 @@ isort==8.0.1
     # via -r api/requirements.in
 jinja2==3.1.6
     # via litellm
-jiter==0.13.0
+jiter==0.14.0
     # via openai
 joblib==1.5.3
     # via scikit-learn
@@ -288,7 +288,7 @@ mwxml==0.3.8
     # via
     #   -r api/requirements.in
     #   mwcli
-mypy==1.20.0
+mypy==1.20.1
     # via -r api/requirements.in
 mypy-extensions==1.1.0
     # via
@@ -403,7 +403,7 @@ pycparser==3.0
     # via cffi
 pycryptodome==3.23.0
     # via matrix-nio
-pydantic==2.12.5
+pydantic==2.13.0
     # via
     #   -r api/requirements.in
     #   fastapi
@@ -419,7 +419,7 @@ pydantic==2.12.5
     #   pydantic-settings
     #   qdrant-client
     #   ragas
-pydantic-core==2.41.5
+pydantic-core==2.46.0
     # via
     #   instructor
     #   pydantic
@@ -460,7 +460,7 @@ python-dotenv==1.2.2
     #   pydantic-settings
 python-json-logger==4.1.0
     # via -r api/requirements.in
-python-multipart==0.0.24
+python-multipart==0.0.26
     # via mcp
 python-olm==3.2.16
     # via matrix-nio
@@ -568,7 +568,7 @@ tqdm==4.67.3
     #   openai
     #   ragas
     #   transformers
-transformers==5.5.3
+transformers==5.5.4
     # via -r api/requirements.in
 typer==0.9.4
     # via
@@ -620,7 +620,7 @@ uvicorn==0.44.0
     # via
     #   -r api/requirements.in
     #   mcp
-virtualenv==21.2.1
+virtualenv==21.2.3
     # via pre-commit
 websockets==16.0
     # via -r api/requirements.in
@@ -633,7 +633,7 @@ xxhash==3.6.0
     #   langsmith
 yarl==1.23.0
     # via aiohttp
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata
 zstandard==0.25.0
     # via langsmith

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -36,7 +36,7 @@
         "fuse.js": "^7.1.0",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.475.0",
-        "next": "15.5.11",
+        "next": "^15.5.15",
         "next-themes": "^0.4.6",
         "nextjs-toploader": "^3.9.17",
         "react": "^19.0.0",
@@ -2211,9 +2211,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.11.tgz",
-      "integrity": "sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -2259,9 +2259,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -2275,9 +2275,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -2291,9 +2291,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -2307,9 +2307,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -2339,9 +2339,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -10677,12 +10677,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.11.tgz",
-      "integrity": "sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.11",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10695,14 +10695,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -46,7 +46,7 @@
     "fuse.js": "^7.1.0",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.475.0",
-    "next": "15.5.11",
+    "next": "^15.5.15",
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",
     "react": "^19.0.0",

--- a/web/src/app/admin/escalations/EscalationReviewPanel.tsx
+++ b/web/src/app/admin/escalations/EscalationReviewPanel.tsx
@@ -1046,9 +1046,14 @@ export function EscalationReviewPanel({
                     variant="outline"
                     size="sm"
                     className="text-muted-foreground hover:text-foreground"
-                    onClick={() => onOpenChange(false)}
+                    onClick={handleClose}
                     disabled={isActionInProgress}
                   >
+                    {isClosing ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <XCircle className="mr-2 h-4 w-4" />
+                    )}
                     Close Without FAQ
                   </Button>
                 )}


### PR DESCRIPTION
## Summary
- **Proactive impersonation scanner**: New background service that periodically searches the Matrix user directory and public room directory for impersonation attempts. Detects accounts with display names matching Bisq staff and fake support rooms.
- **Educational warnings**: Auto-posts scam warnings in monitored public rooms when impersonators are found (rate-limited to 1 per 24h per room).
- **Escalation close bug**: "Close Without FAQ" button only dismissed the dialog without actually closing the escalation in the database. Now properly calls the close API.

## Changes
- `api/app/channels/trust_monitor/proactive_scanner.py` (new): Background scanner with user directory search, public room directory search, and scam warning posting
- `api/app/main.py`: Wire scanner into lifespan (start/stop), persist findings via trust monitor store
- `web/src/app/admin/escalations/EscalationReviewPanel.tsx`: Fix "Close Without FAQ" to call handleClose instead of just dismissing dialog

## Test plan
- [x] 2657 API tests pass
- [x] Web frontend builds and lints clean
- [x] Docker image builds
- [x] Manual verification: close API works for stuck escalations (7 cleaned up on production)
- [ ] Deploy and verify scanner starts, performs first scan after 30s delay
- [ ] Verify scam warnings post correctly on impersonator detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated proactive scanning to detect suspected user impersonation and fake public rooms, persist findings, publish alerts, and send rate‑limited educational warnings to monitored rooms; scanner starts/stops with the app lifecycle for continuous protection.

* **UX/Improvements**
  * Unified “Close Without FAQ” handling and added a loading indicator while closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->