### PR TITLE
Overhaul security alerts UI and fix proactive alert surface

### DIFF
--- a/api/app/channels/trust_monitor/alert_formatting.py
+++ b/api/app/channels/trust_monitor/alert_formatting.py
@@ -44,6 +44,18 @@ def _stringify(value: Any) -> str:
     return str(value)
 
 
+def _sanitize_matrix_text(value: Any) -> str:
+    """Make untrusted text safe to inline into a Matrix markdown message.
+
+    Strips newlines (preserves the line-based layout) and neutralizes
+    `@room`/`@here` mentions so a malicious display name can't ping the
+    whole staff room.
+    """
+    text = _stringify(value).replace("\r", " ").replace("\n", " ")
+    text = text.replace("@room", "@\u200broom").replace("@here", "@\u200bhere")
+    return text
+
+
 def _detector_label(detector_key: str) -> str:
     return _DETECTOR_LABELS.get(detector_key, _humanize_key(detector_key))
 
@@ -75,20 +87,22 @@ def format_trust_alert_for_matrix(finding: TrustFinding) -> str:
     )
     detection_method = _detection_method_label(evidence.get("detection_method"))
 
-    display_name = finding.suspect_display_name or "(no display name)"
+    display_name = _sanitize_matrix_text(
+        finding.suspect_display_name or "(no display name)"
+    )
 
     lines: list[str] = []
     lines.append(f"**🚨 Trust monitor alert — {detector_label}**")
     lines.append("")
     lines.append(f"**Suspect:** {display_name}")
-    lines.append(f"`{finding.suspect_actor_id}`")
+    lines.append(f"`{_sanitize_matrix_text(finding.suspect_actor_id)}`")
     if matched_staff:
-        lines.append(f"**Collides with staff:** {matched_staff}")
+        lines.append(f"**Collides with staff:** {_sanitize_matrix_text(matched_staff)}")
     lines.append("")
     lines.append(f"**Risk score:** {finding.score:.2f} ({risk_label})")
     if detection_method:
         lines.append(f"**Detection method:** {detection_method}")
-    lines.append(f"**Channel:** {finding.channel_id}")
+    lines.append(f"**Channel:** {_sanitize_matrix_text(finding.channel_id)}")
 
     extra_signals = [
         (key, value)
@@ -99,7 +113,7 @@ def format_trust_alert_for_matrix(finding: TrustFinding) -> str:
         lines.append("")
         lines.append("**Other signals:**")
         for key, value in extra_signals:
-            lines.append(f"- {_humanize_key(key)}: {_stringify(value)}")
+            lines.append(f"- {_humanize_key(key)}: {_sanitize_matrix_text(value)}")
 
     lines.append("")
     lines.append("Open in Admin UI to view avatars, take action, or mark as benign.")

--- a/api/app/channels/trust_monitor/alert_formatting.py
+++ b/api/app/channels/trust_monitor/alert_formatting.py
@@ -1,0 +1,106 @@
+"""Human-readable formatting for trust monitor Matrix staff-room alerts.
+
+Strips mxc:// URLs (clients can't render them inline) and produces
+markdown bold/bullets that render natively in Element/Cinny/etc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.channels.trust_monitor.models import TrustFinding
+
+_DETECTOR_LABELS = {
+    "staff_name_collision": "Staff name collision",
+    "silent_early_observer": "Silent early observer",
+    "user_directory_impersonation": "User directory impersonation",
+}
+
+_DETECTION_METHOD_LABELS = {
+    "user_directory_search": "User directory search",
+    "public_room_scan": "Public room scan",
+    "message_event": "In-room message",
+}
+
+_HIDDEN_EVIDENCE_KEYS = {
+    "suspect_avatar_url",
+    "staff_avatar_url",
+    "user_id",  # already shown via suspect_actor_id
+    "display_name",  # already shown via suspect_display_name
+    "detection_method",  # rendered as a labelled section
+    "matched_staff_name",  # rendered as a labelled section
+    "staff_display_name",
+    "suspect_actor_id",
+}
+
+
+def _humanize_key(key: str) -> str:
+    return key.replace("_", " ").strip().capitalize()
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+def _detector_label(detector_key: str) -> str:
+    return _DETECTOR_LABELS.get(detector_key, _humanize_key(detector_key))
+
+
+def _detection_method_label(value: str | None) -> str | None:
+    if not value:
+        return None
+    return _DETECTION_METHOD_LABELS.get(value, _humanize_key(value))
+
+
+def _risk_label(score: float) -> str:
+    if score >= 0.9:
+        return "immediate review"
+    if score >= 0.75:
+        return "high confidence"
+    return "monitor closely"
+
+
+def format_trust_alert_for_matrix(finding: TrustFinding) -> str:
+    """Render a Matrix-friendly alert for the staff room.
+
+    Output is markdown-light (Matrix clients render `**bold**` and bullets).
+    """
+    evidence = finding.evidence_summary or {}
+    detector_label = _detector_label(finding.detector_key)
+    risk_label = _risk_label(float(finding.score))
+    matched_staff = (
+        evidence.get("matched_staff_name") or evidence.get("staff_display_name") or None
+    )
+    detection_method = _detection_method_label(evidence.get("detection_method"))
+
+    display_name = finding.suspect_display_name or "(no display name)"
+
+    lines: list[str] = []
+    lines.append(f"**🚨 Trust monitor alert — {detector_label}**")
+    lines.append("")
+    lines.append(f"**Suspect:** {display_name}")
+    lines.append(f"`{finding.suspect_actor_id}`")
+    if matched_staff:
+        lines.append(f"**Collides with staff:** {matched_staff}")
+    lines.append("")
+    lines.append(f"**Risk score:** {finding.score:.2f} ({risk_label})")
+    if detection_method:
+        lines.append(f"**Detection method:** {detection_method}")
+    lines.append(f"**Channel:** {finding.channel_id}")
+
+    extra_signals = [
+        (key, value)
+        for key, value in evidence.items()
+        if key not in _HIDDEN_EVIDENCE_KEYS
+    ]
+    if extra_signals:
+        lines.append("")
+        lines.append("**Other signals:**")
+        for key, value in extra_signals:
+            lines.append(f"- {_humanize_key(key)}: {_stringify(value)}")
+
+    lines.append("")
+    lines.append("Open in Admin UI to view avatars, take action, or mark as benign.")
+    return "\n".join(lines)

--- a/api/app/channels/trust_monitor/proactive_persistence.py
+++ b/api/app/channels/trust_monitor/proactive_persistence.py
@@ -1,0 +1,53 @@
+"""Pure persister for proactive trust-monitor findings.
+
+Extracted so the policy-override behavior can be unit-tested without
+spinning up the full FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+_logger = logging.getLogger(__name__)
+
+
+def persist_proactive_finding(
+    *,
+    trust_monitor_service: Any,
+    sync_rooms: Iterable[str],
+    result: Any,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Persist a proactive detector result, honoring the policy alert surface.
+
+    The proactive scanner hardcodes ``alert_surface=BOTH`` on its detector
+    results. That bypasses the operator-configurable policy, so we resolve
+    the effective surface from the policy service here before storing.
+    """
+    log = logger or _logger
+    try:
+        space_id = next(iter(sync_rooms), "proactive_scan")
+        policy = trust_monitor_service.policy_service.get_policy()
+        finding = trust_monitor_service.store.upsert_finding(
+            detector_key=result.detector_key,
+            channel_id="matrix",
+            space_id=space_id,
+            suspect_actor_key=result.suspect_actor_key,
+            suspect_actor_id=result.suspect_actor_id,
+            suspect_display_name=result.suspect_display_name,
+            score=result.score,
+            alert_surface=policy.alert_surface,
+            evidence_summary=result.evidence_summary,
+            created_at=result.occurred_at,
+            notify=True,
+        )
+        if trust_monitor_service.publisher:
+            trust_monitor_service.publisher.publish(finding)
+    except Exception:
+        log.warning(
+            "Failed to persist proactive finding for %s (%s)",
+            getattr(result, "suspect_actor_id", "?"),
+            getattr(result, "detector_key", "?"),
+            exc_info=True,
+        )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -115,6 +115,10 @@ async def lifespan(app: FastAPI):
     app.state.trust_monitor_service = None
     app.state.chatops_audit_store = None
 
+    import httpx as _httpx
+
+    app.state.matrix_media_http_client = _httpx.AsyncClient(follow_redirects=True)
+
     # Initialize task metrics persistence and restore values
     logger.info("Initializing task metrics persistence...")
     from app.metrics.task_metrics import restore_metrics_from_database
@@ -445,26 +449,20 @@ async def lifespan(app: FastAPI):
                     ResponseMetadata,
                     UserContext,
                 )
+                from app.channels.trust_monitor.alert_formatting import (
+                    format_trust_alert_for_matrix,
+                )
 
                 target = app.state.trust_monitor_policy_service.get_policy().matrix_staff_room_id or getattr(
                     settings, "MATRIX_STAFF_ROOM", ""
                 )
                 if not target:
                     return
-                summary = finding.evidence_summary
-                lines = [
-                    f"Trust monitor finding: {finding.detector_key}",
-                    f"User: {finding.suspect_actor_id}",
-                    f"Display name: {finding.suspect_display_name or '-'}",
-                    f"Score: {finding.score:.2f}",
-                ]
-                for key, value in summary.items():
-                    lines.append(f"{key}: {value}")
                 message = OutgoingMessage(
                     message_id=f"trust-{finding.id}",
-                    in_reply_to=str(finding.id),
+                    in_reply_to="",  # empty disables m.in_reply_to (no event to reply to)
                     channel=ChannelType.MATRIX,
-                    answer="\n".join(lines),
+                    answer=format_trust_alert_for_matrix(finding),
                     user=UserContext(
                         user_id="trust-monitor",
                         session_id=None,
@@ -540,32 +538,18 @@ async def lifespan(app: FastAPI):
 
             sync_rooms = resolve_allowed_sync_rooms(settings)
 
+            from app.channels.trust_monitor.proactive_persistence import (
+                persist_proactive_finding,
+            )
+
             def _handle_proactive_finding(result):
                 """Persist finding via trust monitor store and publish alert."""
-                try:
-                    space_id = next(iter(sync_rooms), "proactive_scan")
-                    finding = trust_monitor_service.store.upsert_finding(
-                        detector_key=result.detector_key,
-                        channel_id="matrix",
-                        space_id=space_id,
-                        suspect_actor_key=result.suspect_actor_key,
-                        suspect_actor_id=result.suspect_actor_id,
-                        suspect_display_name=result.suspect_display_name,
-                        score=result.score,
-                        alert_surface=result.alert_surface,
-                        evidence_summary=result.evidence_summary,
-                        created_at=result.occurred_at,
-                        notify=True,
-                    )
-                    if trust_monitor_service.publisher:
-                        trust_monitor_service.publisher.publish(finding)
-                except Exception:
-                    logger.warning(
-                        "Failed to persist proactive finding for %s (%s)",
-                        result.suspect_actor_id,
-                        result.detector_key,
-                        exc_info=True,
-                    )
+                persist_proactive_finding(
+                    trust_monitor_service=trust_monitor_service,
+                    sync_rooms=sync_rooms,
+                    result=result,
+                    logger=logger,
+                )
 
             scanner = ProactiveImpersonationScanner(
                 homeserver_url=settings.MATRIX_HOMESERVER_URL,
@@ -730,6 +714,10 @@ async def lifespan(app: FastAPI):
     # For example, rag_service might have a cleanup method
     if hasattr(app.state.rag_service, "cleanup"):
         await app.state.rag_service.cleanup()
+
+    matrix_media_client = getattr(app.state, "matrix_media_http_client", None)
+    if matrix_media_client is not None:
+        await matrix_media_client.aclose()
 
 
 # Create FastAPI application

--- a/api/app/routes/admin/trust_monitor.py
+++ b/api/app/routes/admin/trust_monitor.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from app.core.security import verify_admin_access
-from fastapi import APIRouter, Depends, HTTPException, Request
+from app.services.matrix_media_proxy import MediaProxyError, fetch_matrix_media
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel
 
 router = APIRouter(
@@ -388,6 +389,44 @@ def mark_benign(
         actor_id=(payload.actor_id if payload and payload.actor_id else "admin"),
     )
     return _finding_response(updated)
+
+
+def _matrix_access_token(request: Request) -> str | None:
+    matrix_channel = getattr(request.app.state, "matrix_channel", None)
+    runtime = getattr(matrix_channel, "runtime", None)
+    if runtime is None:
+        return None
+    matrix_client = runtime.resolve_optional("matrix_client")
+    return getattr(matrix_client, "access_token", None) if matrix_client else None
+
+
+@router.get("/matrix-media/{server_name}/{media_id}")
+async def proxy_matrix_media(
+    server_name: str, media_id: str, request: Request
+) -> Response:
+    """Proxy a Matrix mxc:// reference for the admin UI.
+
+    The frontend never sees the access token. Avatars only — small payloads.
+    """
+    settings = request.app.state.settings
+    http_client = request.app.state.matrix_media_http_client
+
+    try:
+        payload = await fetch_matrix_media(
+            homeserver_url=settings.MATRIX_HOMESERVER_URL,
+            access_token=_matrix_access_token(request),
+            server_name=server_name,
+            media_id=media_id,
+            http_client=http_client,
+        )
+    except MediaProxyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    return Response(
+        content=payload.content,
+        media_type=payload.content_type,
+        headers={"Cache-Control": "private, max-age=3600"},
+    )
 
 
 # Resolve Pydantic forward references for FastAPI response models in isolated test imports.

--- a/api/app/services/matrix_media_proxy.py
+++ b/api/app/services/matrix_media_proxy.py
@@ -1,0 +1,125 @@
+"""Proxy that downloads Matrix media via the local homeserver.
+
+Used by the admin security UI to render avatars referenced by ``mxc://``
+URIs in trust-monitor evidence. Centralized so credentials never leave
+the backend.
+
+The Matrix spec moved authenticated media to
+``/_matrix/client/v1/media/download/{server}/{mediaId}`` (MSC3916, June
+2024). matrix.org now requires it. We try v1 first and fall back to the
+legacy unauthenticated v3 endpoint for old/self-hosted servers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+# Avatars are tiny — cap at 2 MB to defend against pathological responses.
+_MAX_BYTES = 2 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 8.0
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._\-:]+$")
+
+
+class MediaProxyError(Exception):
+    """Raised when upstream media cannot be retrieved."""
+
+    def __init__(self, message: str, *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class MediaPayload:
+    content: bytes
+    content_type: str
+
+
+class _AsyncHttpClient(Protocol):
+    async def get(self, url: str, *, headers: dict[str, str], timeout: float): ...
+
+
+def validate_segment(value: str, *, field: str) -> str:
+    """Reject anything that could escape the URL path."""
+    if not value or not _SAFE_SEGMENT_RE.match(value):
+        raise MediaProxyError(
+            f"Invalid {field}",
+            status_code=400,
+        )
+    return value
+
+
+def _strip_trailing_slash(url: str) -> str:
+    return url.rstrip("/")
+
+
+async def fetch_matrix_media(
+    *,
+    homeserver_url: str,
+    access_token: str | None,
+    server_name: str,
+    media_id: str,
+    http_client: _AsyncHttpClient,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> MediaPayload:
+    """Fetch media from the homeserver, trying authenticated then legacy endpoints."""
+    if not homeserver_url:
+        raise MediaProxyError("Matrix homeserver not configured", status_code=503)
+
+    server = validate_segment(server_name, field="server name")
+    media = validate_segment(media_id, field="media id")
+    base = _strip_trailing_slash(homeserver_url)
+
+    attempts: list[tuple[str, dict[str, str]]] = []
+    if access_token:
+        attempts.append(
+            (
+                f"{base}/_matrix/client/v1/media/download/{server}/{media}",
+                {"Authorization": f"Bearer {access_token}"},
+            )
+        )
+    attempts.append(
+        (
+            f"{base}/_matrix/media/v3/download/{server}/{media}",
+            {},
+        )
+    )
+
+    last_status: int | None = None
+    for url, headers in attempts:
+        try:
+            response = await http_client.get(
+                url, headers=headers, timeout=timeout_seconds
+            )
+        except Exception as exc:  # network errors, timeouts
+            logger.debug("Matrix media fetch failed for %s: %s", url, exc)
+            last_status = 504
+            continue
+
+        status = getattr(response, "status_code", None)
+        if status is None:
+            status = getattr(response, "status", None)
+        if status == 200:
+            content = getattr(response, "content", None)
+            if content is None and hasattr(response, "read"):
+                content = await response.read()
+            if not isinstance(content, (bytes, bytearray)):
+                raise MediaProxyError("Upstream returned non-bytes body")
+            if len(content) > _MAX_BYTES:
+                raise MediaProxyError("Media too large", status_code=413)
+            content_type = "application/octet-stream"
+            headers_obj = getattr(response, "headers", None)
+            if headers_obj is not None:
+                ct = headers_obj.get("content-type") or headers_obj.get("Content-Type")
+                if ct:
+                    content_type = ct.split(";", 1)[0].strip()
+            return MediaPayload(content=bytes(content), content_type=content_type)
+        last_status = status
+
+    if last_status == 404:
+        raise MediaProxyError("Media not found", status_code=404)
+    raise MediaProxyError(f"Upstream returned status {last_status}", status_code=502)

--- a/api/tests/channels/trust_monitor/test_alert_formatting.py
+++ b/api/tests/channels/trust_monitor/test_alert_formatting.py
@@ -113,3 +113,41 @@ def test_format_starts_with_bold_alert_header() -> None:
     first_line = text.splitlines()[0]
     assert first_line.startswith("**") and first_line.endswith("**")
     assert "Trust monitor alert" in first_line
+
+
+def test_format_strips_newlines_from_display_name() -> None:
+    finding = _make_finding(suspect_display_name="alice\nbob")
+    text = format_trust_alert_for_matrix(finding)
+    assert "**Suspect:** alice bob" in text or "**Suspect:** alice  bob" in text
+
+
+def test_format_neutralizes_room_mention_in_display_name() -> None:
+    finding = _make_finding(suspect_display_name="@room everyone")
+    text = format_trust_alert_for_matrix(finding)
+    assert "@room" not in text
+
+
+def test_format_neutralizes_room_mention_in_evidence_value() -> None:
+    finding = _make_finding(
+        evidence_summary={
+            "matched_staff_name": "@room please",
+            "detection_method": "user_directory_search",
+        }
+    )
+    text = format_trust_alert_for_matrix(finding)
+    assert "@room" not in text
+
+
+def test_format_strips_newlines_from_extra_signal_value() -> None:
+    finding = _make_finding(
+        evidence_summary={
+            "detection_method": "user_directory_search",
+            "matched_staff_name": "alice",
+            "notes": "line one\nline two",
+        }
+    )
+    text = format_trust_alert_for_matrix(finding)
+    notes_lines = [line for line in text.splitlines() if "Notes" in line]
+    assert notes_lines, "Notes line missing from output"
+    for line in notes_lines:
+        assert "line one" in line and "line two" in line

--- a/api/tests/channels/trust_monitor/test_alert_formatting.py
+++ b/api/tests/channels/trust_monitor/test_alert_formatting.py
@@ -1,0 +1,115 @@
+"""Tests for the trust monitor Matrix alert formatter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from app.channels.trust_monitor.alert_formatting import format_trust_alert_for_matrix
+
+
+def _make_finding(**overrides):
+    base = dict(
+        id=42,
+        detector_key="user_directory_impersonation",
+        channel_id="matrix",
+        space_id="proactive_scan",
+        suspect_actor_id="@casaamigis:matrix.org",
+        suspect_display_name="suddenwhipvapor",
+        score=0.95,
+        status="open",
+        alert_surface="admin_ui",
+        evidence_summary={
+            "detection_method": "user_directory_search",
+            "matched_staff_name": "suddenwhipvapor",
+            "user_id": "@casaamigis:matrix.org",
+            "display_name": "suddenwhipvapor",
+            "suspect_avatar_url": "mxc://matrix.org/abc",
+            "staff_avatar_url": "mxc://matrix.org/xyz",
+        },
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        last_notified_at=None,
+        notification_count=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_format_omits_mxc_avatar_urls() -> None:
+    text = format_trust_alert_for_matrix(_make_finding())
+    assert "mxc://" not in text
+    assert "suspect_avatar_url" not in text
+
+
+def test_format_uses_friendly_detector_label() -> None:
+    text = format_trust_alert_for_matrix(_make_finding())
+    assert "User directory impersonation" in text
+    assert "user_directory_impersonation" not in text
+
+
+def test_format_includes_suspect_and_collision_target() -> None:
+    text = format_trust_alert_for_matrix(_make_finding())
+    assert "@casaamigis:matrix.org" in text
+    assert "Collides with staff" in text
+    assert "suddenwhipvapor" in text
+
+
+def test_format_shows_risk_label_for_high_score() -> None:
+    text = format_trust_alert_for_matrix(_make_finding(score=0.95))
+    assert "0.95" in text
+    assert "immediate review" in text
+
+
+def test_format_shows_other_signals_when_present() -> None:
+    finding = _make_finding(
+        evidence_summary={
+            "detection_method": "user_directory_search",
+            "heuristic_version": "v3",
+            "early_read_hits": 12,
+        }
+    )
+    text = format_trust_alert_for_matrix(finding)
+    assert "Other signals:" in text
+    assert "Heuristic version" in text
+    assert "Early read hits" in text
+
+
+def test_format_skips_other_signals_section_when_empty() -> None:
+    finding = _make_finding(
+        evidence_summary={
+            "matched_staff_name": "alice",
+            "detection_method": "user_directory_search",
+            "user_id": "@x:matrix.org",
+            "display_name": "alice",
+            "suspect_avatar_url": "mxc://matrix.org/x",
+            "staff_avatar_url": "mxc://matrix.org/y",
+        }
+    )
+    text = format_trust_alert_for_matrix(finding)
+    assert "Other signals:" not in text
+
+
+def test_format_handles_missing_display_name() -> None:
+    finding = _make_finding(suspect_display_name="")
+    text = format_trust_alert_for_matrix(finding)
+    assert "(no display name)" in text
+
+
+def test_format_friendly_detection_method_label() -> None:
+    finding = _make_finding(
+        evidence_summary={
+            "detection_method": "user_directory_search",
+            "matched_staff_name": "alice",
+        }
+    )
+    text = format_trust_alert_for_matrix(finding)
+    assert "User directory search" in text
+    assert "user_directory_search" not in text
+
+
+def test_format_starts_with_bold_alert_header() -> None:
+    text = format_trust_alert_for_matrix(_make_finding())
+    first_line = text.splitlines()[0]
+    assert first_line.startswith("**") and first_line.endswith("**")
+    assert "Trust monitor alert" in first_line

--- a/api/tests/channels/trust_monitor/test_proactive_persistence.py
+++ b/api/tests/channels/trust_monitor/test_proactive_persistence.py
@@ -1,0 +1,114 @@
+"""Tests for the proactive trust-monitor persister.
+
+Verifies the policy alert surface overrides whatever the detector produced,
+which is the bug we are fixing: proactive scanner hardcodes BOTH but the
+operator policy may want ADMIN_UI only.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from app.channels.trust_monitor.models import TrustAlertSurface
+from app.channels.trust_monitor.proactive_persistence import persist_proactive_finding
+
+
+def _make_result(surface: TrustAlertSurface) -> SimpleNamespace:
+    return SimpleNamespace(
+        detector_key="user_directory_impersonation",
+        suspect_actor_id="@bad:matrix.org",
+        suspect_actor_key="@bad:matrix.org",
+        suspect_display_name="suddenwhipvapor",
+        score=0.95,
+        evidence_summary={"matched_staff_name": "suddenwhipvapor"},
+        alert_surface=surface,
+        occurred_at=datetime.now(UTC),
+    )
+
+
+def _make_service(policy_surface: TrustAlertSurface):
+    captured: dict = {}
+
+    class _Store:
+        def upsert_finding(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(id="finding-1", **kwargs)
+
+    class _Publisher:
+        published: list = []
+
+        def publish(self, finding):
+            self.published.append(finding)
+
+    publisher = _Publisher()
+    service = SimpleNamespace(
+        store=_Store(),
+        publisher=publisher,
+        policy_service=SimpleNamespace(
+            get_policy=lambda: SimpleNamespace(alert_surface=policy_surface)
+        ),
+    )
+    return service, captured, publisher
+
+
+def test_persister_overrides_detector_surface_with_policy_admin_ui() -> None:
+    service, captured, publisher = _make_service(TrustAlertSurface.ADMIN_UI)
+    result = _make_result(TrustAlertSurface.BOTH)
+
+    persist_proactive_finding(
+        trust_monitor_service=service,
+        sync_rooms=["!room:matrix.org"],
+        result=result,
+    )
+
+    assert captured["alert_surface"] == TrustAlertSurface.ADMIN_UI
+    assert len(publisher.published) == 1
+
+
+def test_persister_uses_policy_both_when_configured() -> None:
+    service, captured, _ = _make_service(TrustAlertSurface.BOTH)
+    result = _make_result(TrustAlertSurface.ADMIN_UI)
+
+    persist_proactive_finding(
+        trust_monitor_service=service,
+        sync_rooms=["!room:matrix.org"],
+        result=result,
+    )
+
+    assert captured["alert_surface"] == TrustAlertSurface.BOTH
+
+
+def test_persister_falls_back_space_id_when_no_sync_rooms() -> None:
+    service, captured, _ = _make_service(TrustAlertSurface.ADMIN_UI)
+    result = _make_result(TrustAlertSurface.BOTH)
+
+    persist_proactive_finding(
+        trust_monitor_service=service,
+        sync_rooms=[],
+        result=result,
+    )
+
+    assert captured["space_id"] == "proactive_scan"
+
+
+def test_persister_swallows_exceptions() -> None:
+    class _ExplodingStore:
+        def upsert_finding(self, **_):
+            raise RuntimeError("boom")
+
+    service = SimpleNamespace(
+        store=_ExplodingStore(),
+        publisher=None,
+        policy_service=SimpleNamespace(
+            get_policy=lambda: SimpleNamespace(alert_surface=TrustAlertSurface.ADMIN_UI)
+        ),
+    )
+    result = _make_result(TrustAlertSurface.BOTH)
+
+    # Must not raise — the proactive scanner loop relies on this.
+    persist_proactive_finding(
+        trust_monitor_service=service,
+        sync_rooms=["!room:matrix.org"],
+        result=result,
+    )

--- a/api/tests/services/test_matrix_media_proxy.py
+++ b/api/tests/services/test_matrix_media_proxy.py
@@ -1,0 +1,162 @@
+"""Tests for the Matrix media proxy fetcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from app.services.matrix_media_proxy import (
+    MediaProxyError,
+    fetch_matrix_media,
+    validate_segment,
+)
+
+
+@dataclass
+class _FakeResponse:
+    status_code: int
+    content: bytes = b""
+    headers: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.headers is None:
+            self.headers = {}
+
+
+class _FakeClient:
+    def __init__(self, responses: list[_FakeResponse]):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    async def get(self, url: str, *, headers: dict[str, str], timeout: float):
+        self.calls.append((url, dict(headers)))
+        if not self._responses:
+            raise RuntimeError("no more fake responses")
+        return self._responses.pop(0)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["matrix.org", "abc123", "AB_xy.zw-1", "matrix.example:8448", "ABCDEFG12345"],
+)
+def test_validate_segment_accepts_safe_values(value: str) -> None:
+    assert validate_segment(value, field="x") == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "../etc/passwd", "foo/bar", "foo bar", "foo\x00bar", "foo?bar"],
+)
+def test_validate_segment_rejects_unsafe_values(value: str) -> None:
+    with pytest.raises(MediaProxyError):
+        validate_segment(value, field="x")
+
+
+@pytest.mark.asyncio
+async def test_fetch_uses_authenticated_endpoint_when_token_present() -> None:
+    client = _FakeClient(
+        [_FakeResponse(200, b"PNGDATA", {"Content-Type": "image/png"})]
+    )
+    payload = await fetch_matrix_media(
+        homeserver_url="https://matrix.org",
+        access_token="syt_xxx",
+        server_name="matrix.org",
+        media_id="abc123",
+        http_client=client,
+    )
+    assert payload.content == b"PNGDATA"
+    assert payload.content_type == "image/png"
+    url, headers = client.calls[0]
+    assert "/client/v1/media/download/matrix.org/abc123" in url
+    assert headers["Authorization"] == "Bearer syt_xxx"
+
+
+@pytest.mark.asyncio
+async def test_fetch_falls_back_to_legacy_v3_when_no_token() -> None:
+    client = _FakeClient([_FakeResponse(200, b"JPG", {"Content-Type": "image/jpeg"})])
+    payload = await fetch_matrix_media(
+        homeserver_url="https://matrix.org",
+        access_token=None,
+        server_name="matrix.org",
+        media_id="abc",
+        http_client=client,
+    )
+    assert payload.content_type == "image/jpeg"
+    assert "/_matrix/media/v3/download/matrix.org/abc" in client.calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_falls_back_to_v3_when_v1_fails() -> None:
+    client = _FakeClient(
+        [
+            _FakeResponse(401),
+            _FakeResponse(200, b"OK", {"Content-Type": "image/png"}),
+        ]
+    )
+    payload = await fetch_matrix_media(
+        homeserver_url="https://matrix.org",
+        access_token="syt_xxx",
+        server_name="matrix.org",
+        media_id="abc",
+        http_client=client,
+    )
+    assert payload.content == b"OK"
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_404_when_all_attempts_404() -> None:
+    client = _FakeClient([_FakeResponse(404), _FakeResponse(404)])
+    with pytest.raises(MediaProxyError) as excinfo:
+        await fetch_matrix_media(
+            homeserver_url="https://matrix.org",
+            access_token="syt_xxx",
+            server_name="matrix.org",
+            media_id="missing",
+            http_client=client,
+        )
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_invalid_server_name() -> None:
+    client = _FakeClient([])
+    with pytest.raises(MediaProxyError) as excinfo:
+        await fetch_matrix_media(
+            homeserver_url="https://matrix.org",
+            access_token=None,
+            server_name="../etc",
+            media_id="abc",
+            http_client=client,
+        )
+    assert excinfo.value.status_code == 400
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_oversized_content() -> None:
+    big = b"x" * (3 * 1024 * 1024)
+    client = _FakeClient([_FakeResponse(200, big, {"Content-Type": "image/png"})])
+    with pytest.raises(MediaProxyError) as excinfo:
+        await fetch_matrix_media(
+            homeserver_url="https://matrix.org",
+            access_token=None,
+            server_name="matrix.org",
+            media_id="abc",
+            http_client=client,
+        )
+    assert excinfo.value.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_fetch_503_when_homeserver_missing() -> None:
+    client = _FakeClient([])
+    with pytest.raises(MediaProxyError) as excinfo:
+        await fetch_matrix_media(
+            homeserver_url="",
+            access_token=None,
+            server_name="matrix.org",
+            media_id="abc",
+            http_client=client,
+        )
+    assert excinfo.value.status_code == 503

--- a/web/src/components/admin/security/AvatarComparison.test.tsx
+++ b/web/src/components/admin/security/AvatarComparison.test.tsx
@@ -56,7 +56,7 @@ describe("AvatarComparison", () => {
         suspectAvatarUrl={null}
         suspectDisplayName="alice"
         suspectActorId="@bad:matrix.org"
-        staffAvatarUrl="https://example.com/alice.png"
+        staffAvatarUrl="mxc://matrix.org/alicepic"
         staffDisplayName="alice"
       />,
     );
@@ -64,7 +64,9 @@ describe("AvatarComparison", () => {
     const root = screen.getByTestId("avatar-comparison");
     const imgs = root.querySelectorAll("img");
     expect(imgs).toHaveLength(1);
-    expect(imgs[0]?.getAttribute("src")).toBe("https://example.com/alice.png");
+    expect(imgs[0]?.getAttribute("src")).toContain(
+      "/matrix-media/matrix.org/alicepic",
+    );
   });
 
   it("shows 'Unknown' when display name is missing", () => {

--- a/web/src/components/admin/security/AvatarComparison.test.tsx
+++ b/web/src/components/admin/security/AvatarComparison.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, within } from "@testing-library/react";
+
+jest.mock("lucide-react", () => {
+  const MockIcon = ({ className }: { className?: string }) => (
+    <svg className={className} />
+  );
+  return new Proxy({}, { get: () => MockIcon });
+});
+
+import { AvatarComparison } from "@/components/admin/security/AvatarComparison";
+
+describe("AvatarComparison", () => {
+  it("renders both avatars and labels when all data is present", () => {
+    render(
+      <AvatarComparison
+        suspectAvatarUrl="mxc://matrix.org/suspectabc"
+        suspectDisplayName="suddenwhipvapor"
+        suspectActorId="@casaamigis:matrix.org"
+        staffAvatarUrl="mxc://matrix.org/staffxyz"
+        staffDisplayName="suddenwhipvapor"
+      />,
+    );
+
+    const root = screen.getByTestId("avatar-comparison");
+    const imgs = root.querySelectorAll("img");
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0]?.getAttribute("src")).toContain("/matrix-media/matrix.org/suspectabc");
+    expect(imgs[1]?.getAttribute("src")).toContain("/matrix-media/matrix.org/staffxyz");
+
+    expect(within(root).getByText("Suspect")).toBeInTheDocument();
+    expect(within(root).getByText("Legitimate staff")).toBeInTheDocument();
+    expect(within(root).getByText("@casaamigis:matrix.org")).toBeInTheDocument();
+    expect(within(root).getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("falls back to initials when no avatar URLs are supplied", () => {
+    render(
+      <AvatarComparison
+        suspectAvatarUrl={null}
+        suspectDisplayName="alice"
+        suspectActorId="@bad:matrix.org"
+        staffAvatarUrl={null}
+        staffDisplayName="alice"
+      />,
+    );
+
+    const root = screen.getByTestId("avatar-comparison");
+    expect(root.querySelectorAll("img")).toHaveLength(0);
+    // Both fallbacks render the same initials text
+    expect(within(root).getAllByText("AL")).toHaveLength(2);
+  });
+
+  it("handles a mixed case where only the suspect avatar is missing", () => {
+    render(
+      <AvatarComparison
+        suspectAvatarUrl={null}
+        suspectDisplayName="alice"
+        suspectActorId="@bad:matrix.org"
+        staffAvatarUrl="https://example.com/alice.png"
+        staffDisplayName="alice"
+      />,
+    );
+
+    const root = screen.getByTestId("avatar-comparison");
+    const imgs = root.querySelectorAll("img");
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]?.getAttribute("src")).toBe("https://example.com/alice.png");
+  });
+
+  it("shows 'Unknown' when display name is missing", () => {
+    render(
+      <AvatarComparison
+        suspectAvatarUrl={null}
+        suspectDisplayName={null}
+        suspectActorId="@x:matrix.org"
+        staffAvatarUrl={null}
+        staffDisplayName=""
+      />,
+    );
+
+    const root = screen.getByTestId("avatar-comparison");
+    expect(within(root).getAllByText("Unknown")).toHaveLength(2);
+  });
+});

--- a/web/src/components/admin/security/AvatarComparison.tsx
+++ b/web/src/components/admin/security/AvatarComparison.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { ArrowLeftRight, ShieldAlert, ShieldCheck } from "lucide-react";
+import { MatrixAvatar } from "@/components/admin/security/MatrixAvatar";
+import { cn } from "@/lib/utils";
+
+export interface AvatarComparisonProps {
+  suspectAvatarUrl: string | null | undefined;
+  suspectDisplayName: string | null | undefined;
+  suspectActorId: string | null | undefined;
+  staffAvatarUrl: string | null | undefined;
+  staffDisplayName: string | null | undefined;
+  className?: string;
+}
+
+/**
+ * Side-by-side comparison of a suspected impersonator and the legitimate
+ * staff member their display name collides with. The visual layout makes
+ * the impersonation obvious at a glance: identical names + (often)
+ * unrelated avatars.
+ */
+export function AvatarComparison({
+  suspectAvatarUrl,
+  suspectDisplayName,
+  suspectActorId,
+  staffAvatarUrl,
+  staffDisplayName,
+  className,
+}: AvatarComparisonProps) {
+  return (
+    <div
+      className={cn(
+        "grid items-stretch gap-3 rounded-2xl border border-border/70 bg-background/40 p-4 sm:grid-cols-[1fr_auto_1fr]",
+        className,
+      )}
+      data-testid="avatar-comparison"
+    >
+      <ComparisonCard
+        tone="suspect"
+        icon={<ShieldAlert className="h-3.5 w-3.5" />}
+        label="Suspect"
+        avatarUrl={suspectAvatarUrl}
+        displayName={suspectDisplayName}
+        secondary={suspectActorId ?? null}
+      />
+
+      <div
+        className="flex items-center justify-center text-muted-foreground"
+        aria-hidden="true"
+      >
+        <ArrowLeftRight className="h-4 w-4" />
+      </div>
+
+      <ComparisonCard
+        tone="staff"
+        icon={<ShieldCheck className="h-3.5 w-3.5" />}
+        label="Legitimate staff"
+        avatarUrl={staffAvatarUrl}
+        displayName={staffDisplayName}
+        secondary="Verified"
+      />
+    </div>
+  );
+}
+
+interface ComparisonCardProps {
+  tone: "suspect" | "staff";
+  icon: React.ReactNode;
+  label: string;
+  avatarUrl: string | null | undefined;
+  displayName: string | null | undefined;
+  secondary: string | null;
+}
+
+function ComparisonCard({
+  tone,
+  icon,
+  label,
+  avatarUrl,
+  displayName,
+  secondary,
+}: ComparisonCardProps) {
+  const isSuspect = tone === "suspect";
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-xl border p-3",
+        isSuspect
+          ? "border-red-500/30 bg-red-500/5"
+          : "border-emerald-500/30 bg-emerald-500/5",
+      )}
+    >
+      <MatrixAvatar
+        avatarUrl={avatarUrl}
+        displayName={displayName}
+        className={cn(
+          "h-14 w-14",
+          isSuspect ? "ring-red-500/40" : "ring-emerald-500/40",
+        )}
+      />
+      <div className="min-w-0">
+        <div
+          className={cn(
+            "inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-[0.16em]",
+            isSuspect ? "text-red-300" : "text-emerald-300",
+          )}
+        >
+          {icon}
+          {label}
+        </div>
+        <div className="mt-1 truncate text-sm font-semibold text-foreground/95">
+          {displayName?.trim() || "Unknown"}
+        </div>
+        {secondary ? (
+          <div className="truncate text-xs text-muted-foreground">
+            {secondary}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/security/MatrixAvatar.test.tsx
+++ b/web/src/components/admin/security/MatrixAvatar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MatrixAvatar } from "@/components/admin/security/MatrixAvatar";
 
 // Radix Avatar only renders <img> after it loads successfully in jsdom; the
@@ -42,5 +42,23 @@ describe("MatrixAvatar", () => {
   it("computes single-name initials", () => {
     render(<MatrixAvatar avatarUrl={null} displayName="suddenwhipvapor" />);
     expect(screen.getByText("SU")).toBeInTheDocument();
+  });
+
+  it("retries rendering when the avatar URL changes after a load error", () => {
+    const { container, rerender } = render(
+      <MatrixAvatar avatarUrl="mxc://matrix.org/firstid" displayName="Bob" />,
+    );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+    // Simulate the first image failing to load
+    fireEvent.error(firstImg!);
+    expect(container.querySelector("img")).toBeNull();
+
+    rerender(
+      <MatrixAvatar avatarUrl="mxc://matrix.org/secondid" displayName="Bob" />,
+    );
+    const secondImg = container.querySelector("img");
+    expect(secondImg).not.toBeNull();
+    expect(secondImg?.getAttribute("src")).toContain("secondid");
   });
 });

--- a/web/src/components/admin/security/MatrixAvatar.test.tsx
+++ b/web/src/components/admin/security/MatrixAvatar.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { MatrixAvatar } from "@/components/admin/security/MatrixAvatar";
+
+// Radix Avatar only renders <img> after it loads successfully in jsdom; the
+// fallback element is rendered eagerly so we assert against initials and the
+// img's src attribute (or absence) instead of waiting for load events.
+
+describe("MatrixAvatar", () => {
+  it("renders fallback initials when avatarUrl is null", () => {
+    render(<MatrixAvatar avatarUrl={null} displayName="Alice Wonder" />);
+    expect(screen.getByText("AW")).toBeInTheDocument();
+  });
+
+  it("uses '?' when display name is empty", () => {
+    render(<MatrixAvatar avatarUrl={null} displayName={null} />);
+    expect(screen.getByText("?")).toBeInTheDocument();
+  });
+
+  it("renders an img with the proxied src for an mxc URI", () => {
+    const { container } = render(
+      <MatrixAvatar
+        avatarUrl="mxc://matrix.org/abcDEF"
+        displayName="Bob"
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toMatch(
+      /\/admin\/security\/matrix-media\/matrix\.org\/abcDEF$/,
+    );
+    expect(img?.getAttribute("alt")).toBe("Bob avatar");
+  });
+
+  it("does not render an img element when the URL is unsupported", () => {
+    const { container } = render(
+      <MatrixAvatar avatarUrl="ftp://example/x" displayName="Bob" />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("BO")).toBeInTheDocument();
+  });
+
+  it("computes single-name initials", () => {
+    render(<MatrixAvatar avatarUrl={null} displayName="suddenwhipvapor" />);
+    expect(screen.getByText("SU")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/admin/security/MatrixAvatar.tsx
+++ b/web/src/components/admin/security/MatrixAvatar.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { resolveAvatarUrl } from "@/lib/matrix-media";
+import { cn } from "@/lib/utils";
+
+export interface MatrixAvatarProps {
+  /** mxc:// URI, https URL, or null/undefined when no avatar is known. */
+  avatarUrl: string | null | undefined;
+  /** Display name used to compute the fallback initials and the alt text. */
+  displayName: string | null | undefined;
+  /** Tailwind size classes; defaults to a 16x16 (h-16 w-16) circle. */
+  className?: string;
+  /** Optional override for fallback styling (e.g. red ring for suspect). */
+  fallbackClassName?: string;
+}
+
+function computeInitials(name: string | null | undefined): string {
+  if (!name) {
+    return "?";
+  }
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "?";
+  }
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase();
+  }
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
+}
+
+/**
+ * Avatar that renders Matrix `mxc://` URIs via the backend media proxy.
+ *
+ * Uses a plain `<img>` so the element exists in the DOM immediately
+ * (predictable for tests) and falls back to initials on load errors or
+ * when no URL is supplied.
+ */
+export function MatrixAvatar({
+  avatarUrl,
+  displayName,
+  className,
+  fallbackClassName,
+}: MatrixAvatarProps) {
+  const resolved = resolveAvatarUrl(avatarUrl);
+  const [errored, setErrored] = useState(false);
+  const initials = computeInitials(displayName);
+  const altName = displayName?.trim() || "Unknown user";
+  const showImage = Boolean(resolved) && !errored;
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted ring-1 ring-border/60",
+        className,
+      )}
+      data-testid="matrix-avatar"
+    >
+      {showImage ? (
+        // eslint-disable-next-line @next/next/no-img-element -- backend-proxied auth-cookie route is incompatible with next/image remote patterns
+        <img
+          src={resolved!}
+          alt={`${altName} avatar`}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        <span
+          className={cn(
+            "select-none text-base font-semibold tracking-wide text-foreground/80",
+            fallbackClassName,
+          )}
+          aria-label={`${altName} initials`}
+        >
+          {initials}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/admin/security/MatrixAvatar.tsx
+++ b/web/src/components/admin/security/MatrixAvatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { resolveAvatarUrl } from "@/lib/matrix-media";
 import { cn } from "@/lib/utils";
 
@@ -45,6 +45,9 @@ export function MatrixAvatar({
 }: MatrixAvatarProps) {
   const resolved = resolveAvatarUrl(avatarUrl);
   const [errored, setErrored] = useState(false);
+  useEffect(() => {
+    setErrored(false);
+  }, [resolved]);
   const initials = computeInitials(displayName);
   const altName = displayName?.trim() || "Unknown user";
   const showImage = Boolean(resolved) && !errored;

--- a/web/src/components/admin/security/SecurityAlertsClient.tsx
+++ b/web/src/components/admin/security/SecurityAlertsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, FilterX, Loader2, ShieldCheck } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { SecurityAlertsInitialData, TrustFinding, TrustFindingCounts, TrustMonitorPolicy } from "@/components/admin/security/types";
@@ -42,14 +42,23 @@ export function SecurityAlertsClient({ initialData }: SecurityAlertsClientProps)
   const statusFilter = searchParams.get("status") ?? "";
   const detectorFilter = searchParams.get("detector") ?? "";
 
+  // Findings-list identity (status_filter + detector_key affect the server
+  // fetch). Other URL params like findingId are local UI state and must NOT
+  // trigger a state reset, otherwise the detail panel flickers on each click.
+  const findingsCacheKey = `${statusFilter}|${detectorFilter}|${initialData.findings?.total ?? 0}`;
+  const lastSyncKeyRef = useRef<string | null>(null);
   useEffect(() => {
+    if (lastSyncKeyRef.current === findingsCacheKey) {
+      return;
+    }
+    lastSyncKeyRef.current = findingsCacheKey;
     setFindings(initialData.findings?.items ?? []);
     setCounts(initialData.counts);
     setPolicy(initialData.policy);
     setOps(initialData.ops);
     setTrustAudit(initialData.trustAudit?.items ?? []);
     setChatopsAudit(initialData.chatopsAudit?.items ?? []);
-  }, [initialData]);
+  }, [initialData, findingsCacheKey]);
 
   useEffect(() => {
     const needsBootstrap = (
@@ -156,18 +165,34 @@ export function SecurityAlertsClient({ initialData }: SecurityAlertsClientProps)
     return statusMatch && detectorMatch;
   }), [detectorFilter, findings, statusFilter]);
 
-  const selectedFindingId = useMemo(() => {
-    const raw = searchParams.get("findingId");
-    if (raw) {
-      const parsed = Number(raw);
-      if (filteredFindings.some((finding) => finding.id === parsed)) {
-        return parsed;
-      }
-    }
-    return filteredFindings[0]?.id ?? null;
-  }, [filteredFindings, searchParams]);
+  // Selection lives in local state so clicks bypass the Next.js server
+  // refetch that would otherwise reset all data and flicker the detail panel.
+  const [explicitSelectedId, setExplicitSelectedId] = useState<number | null>(
+    () => {
+      if (typeof window === "undefined") return null;
+      const raw = new URLSearchParams(window.location.search).get("findingId");
+      const parsed = raw ? Number(raw) : NaN;
+      return Number.isFinite(parsed) ? parsed : null;
+    },
+  );
+
+  const selectedFindingId =
+    explicitSelectedId !== null
+    && filteredFindings.some((finding) => finding.id === explicitSelectedId)
+      ? explicitSelectedId
+      : filteredFindings[0]?.id ?? null;
   const selectedFinding = filteredFindings.find((finding) => finding.id === selectedFindingId) ?? null;
   const hasActiveFilters = Boolean(statusFilter || detectorFilter);
+
+  const handleSelectFinding = useCallback((findingId: number) => {
+    setExplicitSelectedId(findingId);
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      params.set("findingId", String(findingId));
+      const next = `${window.location.pathname}?${params.toString()}`;
+      window.history.replaceState(window.history.state, "", next);
+    }
+  }, []);
 
   const derivedCounts = useMemo<TrustFindingCounts>(() => findings.reduce<TrustFindingCounts>((summary, finding) => {
     summary.total += 1;
@@ -359,7 +384,7 @@ export function SecurityAlertsClient({ initialData }: SecurityAlertsClientProps)
           <SecurityFindingsList
             findings={filteredFindings}
             selectedFindingId={selectedFindingId}
-            onSelect={(findingId) => updateUrl({ findingId: String(findingId) })}
+            onSelect={handleSelectFinding}
           />
         </section>
         <div className="xl:sticky xl:top-24 xl:self-start">

--- a/web/src/components/admin/security/SecurityFindingDetail.test.tsx
+++ b/web/src/components/admin/security/SecurityFindingDetail.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("lucide-react", () => {
+  const MockIcon = ({ className }: { className?: string }) => (
+    <svg className={className} />
+  );
+  return new Proxy({}, { get: () => MockIcon });
+});
+
+import { SecurityFindingDetail } from "@/components/admin/security/SecurityFindingDetail";
+import type { TrustFinding } from "@/components/admin/security/types";
+
+function makeFinding(overrides: Partial<TrustFinding> = {}): TrustFinding {
+  return {
+    id: 99,
+    detector_key: "staff_name_collision",
+    channel_id: "matrix",
+    space_id: "!room:matrix.org",
+    suspect_actor_id: "@casaamigis:matrix.org",
+    suspect_display_name: "suddenwhipvapor",
+    score: 0.95,
+    status: "open",
+    alert_surface: "admin_ui",
+    evidence_summary: {
+      detection_method: "user_directory_search",
+      matched_staff_name: "suddenwhipvapor",
+      user_id: "@casaamigis:matrix.org",
+      display_name: "suddenwhipvapor",
+      suspect_avatar_url: "mxc://matrix.org/suspectabc",
+      staff_avatar_url: "mxc://matrix.org/staffxyz",
+      // intentionally extra-noisy field that should land in "Other signals"
+      heuristic_version: "v3",
+    },
+    created_at: "2026-04-10T09:00:00Z",
+    updated_at: "2026-04-10T09:30:00Z",
+    last_notified_at: null,
+    notification_count: 0,
+    ...overrides,
+  };
+}
+
+describe("SecurityFindingDetail", () => {
+  it("renders the empty state when no finding is selected", () => {
+    render(
+      <SecurityFindingDetail finding={null} isMutating={false} onAction={jest.fn()} />,
+    );
+    expect(screen.getByTestId("security-finding-empty")).toBeInTheDocument();
+  });
+
+  it("renders the avatar comparison when both avatars are present", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding()}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    const comparison = screen.getByTestId("avatar-comparison");
+    expect(within(comparison).getByText("Suspect")).toBeInTheDocument();
+    expect(within(comparison).getByText("Legitimate staff")).toBeInTheDocument();
+    const imgs = comparison.querySelectorAll("img");
+    expect(imgs).toHaveLength(2);
+    // No raw mxc:// URLs visible in the page
+    expect(screen.queryByText(/mxc:\/\//)).toBeNull();
+  });
+
+  it("structures the 'Why it was flagged' section with humanised labels", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding()}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Why it was flagged")).toBeInTheDocument();
+    expect(screen.getByText("Detection method")).toBeInTheDocument();
+    expect(screen.getByText("User directory match")).toBeInTheDocument();
+    expect(screen.getByText("Collides with staff name")).toBeInTheDocument();
+    expect(screen.getByText("Alert destination")).toBeInTheDocument();
+    expect(screen.getByText("Admin UI only")).toBeInTheDocument();
+  });
+
+  it("collapses non-structured signals into the 'Other signals' details element", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding()}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    // Heuristic version is not in the structured set
+    expect(screen.getByText(/Other signals \(1\)/)).toBeInTheDocument();
+    // matched_staff_name is structured: it must NOT show up under "Other signals"
+    const others = screen.getByText(/Other signals/).parentElement!;
+    expect(within(others).queryByText("Matched Staff Name")).toBeNull();
+  });
+
+  it("calls onAction('resolve') when the primary button is clicked", async () => {
+    const onAction = jest.fn();
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding()}
+        isMutating={false}
+        onAction={onAction}
+      />,
+    );
+    const primary = screen.getByRole("button", { name: /resolve finding/i });
+    expect(primary).toHaveAttribute("data-action", "primary");
+    await userEvent.click(primary);
+    expect(onAction).toHaveBeenCalledWith("resolve");
+  });
+
+  it("renders the risk score progress bar with a percentage value", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding({ score: 0.95 })}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "95");
+  });
+});

--- a/web/src/components/admin/security/SecurityFindingDetail.test.tsx
+++ b/web/src/components/admin/security/SecurityFindingDetail.test.tsx
@@ -75,7 +75,7 @@ describe("SecurityFindingDetail", () => {
     );
     expect(screen.getByText("Why it was flagged")).toBeInTheDocument();
     expect(screen.getByText("Detection method")).toBeInTheDocument();
-    expect(screen.getByText("User directory match")).toBeInTheDocument();
+    expect(screen.getByText("User directory search")).toBeInTheDocument();
     expect(screen.getByText("Collides with staff name")).toBeInTheDocument();
     expect(screen.getByText("Alert destination")).toBeInTheDocument();
     expect(screen.getByText("Admin UI only")).toBeInTheDocument();
@@ -109,6 +109,52 @@ describe("SecurityFindingDetail", () => {
     expect(primary).toHaveAttribute("data-action", "primary");
     await userEvent.click(primary);
     expect(onAction).toHaveBeenCalledWith("resolve");
+  });
+
+  it("does not call zero notifications 'Shadow only' for admin_ui findings", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding({
+          alert_surface: "admin_ui",
+          notification_count: 0,
+        })}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    expect(screen.queryByText("Shadow only")).toBeNull();
+    expect(screen.getByText("0× notified")).toBeInTheDocument();
+  });
+
+  it("exposes the full room ID via a title attribute even when truncated", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding({
+          channel_id: "matrix",
+          space_id: "!ilodKeOTMMMDTlGhkf:matrix.org",
+        })}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    const fullId = "!ilodKeOTMMMDTlGhkf:matrix.org";
+    const node = screen.getByTitle(fullId);
+    expect(node.textContent).toContain("…");
+    expect(node.textContent).toContain(":matrix.org");
+  });
+
+  it("renders 'Silent' for findings whose alert_surface is none", () => {
+    render(
+      <SecurityFindingDetail
+        finding={makeFinding({
+          alert_surface: "none",
+          notification_count: 0,
+        })}
+        isMutating={false}
+        onAction={jest.fn()}
+      />,
+    );
+    expect(screen.getByText("Silent")).toBeInTheDocument();
   });
 
   it("renders the risk score progress bar with a percentage value", () => {

--- a/web/src/components/admin/security/SecurityFindingDetail.tsx
+++ b/web/src/components/admin/security/SecurityFindingDetail.tsx
@@ -46,7 +46,7 @@ const STRUCTURED_KEYS = new Set([
 ]);
 
 const DETECTION_METHOD_LABELS: Record<string, string> = {
-  user_directory_search: "User directory match",
+  user_directory_search: "User directory search",
   public_room_scan: "Public room scan",
   message_event: "In-room message",
 };
@@ -266,14 +266,20 @@ export function SecurityFindingDetail({
             value={
               finding.notification_count > 0
                 ? `${finding.notification_count}× notified`
-                : "Shadow only"
+                : finding.alert_surface === "none"
+                  ? "Silent"
+                  : "0× notified"
             }
             hint={`Last notified ${formatTimestamp(finding.last_notified_at)}`}
           />
           <DataRow
             icon={<Hash className="h-3.5 w-3.5" />}
             label="Room scope"
-            value={formatRoomScope(finding.channel_id, finding.space_id)}
+            value={
+              <span title={finding.space_id}>
+                {formatRoomScope(finding.channel_id, finding.space_id)}
+              </span>
+            }
           />
           <DataRow
             icon={<Clock3 className="h-3.5 w-3.5" />}
@@ -365,7 +371,7 @@ export function SecurityFindingDetail({
 interface DataRowProps {
   icon: ReactNode;
   label: string;
-  value: string;
+  value: ReactNode;
   hint?: string;
   accent?: boolean;
 }

--- a/web/src/components/admin/security/SecurityFindingDetail.tsx
+++ b/web/src/components/admin/security/SecurityFindingDetail.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { Activity, BellRing, Clock3, ShieldAlert } from "lucide-react";
+import {
+  Activity,
+  BellRing,
+  Clock3,
+  Hash,
+  Megaphone,
+  ShieldAlert,
+  Wand2,
+} from "lucide-react";
 import type { TrustFinding } from "@/components/admin/security/types";
+import { AvatarComparison } from "@/components/admin/security/AvatarComparison";
 import {
   DETECTOR_ICONS,
   DETECTOR_LABELS,
   FALLBACK_DETECTOR_ICON,
+  formatRoomIdentifier,
   formatStatus,
   STATUS_STYLES,
 } from "@/components/admin/security/securityUi";
@@ -17,11 +27,43 @@ import { cn } from "@/lib/utils";
 interface SecurityFindingDetailProps {
   finding: TrustFinding | null;
   isMutating: boolean;
-  onAction: (action: "resolve" | "false-positive" | "suppress" | "mark-benign") => void;
+  onAction: (
+    action: "resolve" | "false-positive" | "suppress" | "mark-benign",
+  ) => void;
 }
 
+// Keys that AvatarComparison or the structured sections render explicitly —
+// hide them from the generic "Other signals" grid to avoid duplication.
+const STRUCTURED_KEYS = new Set([
+  "suspect_avatar_url",
+  "staff_avatar_url",
+  "matched_staff_name",
+  "user_id",
+  "display_name",
+  "detection_method",
+  "suspect_actor_id",
+  "staff_display_name",
+]);
+
+const DETECTION_METHOD_LABELS: Record<string, string> = {
+  user_directory_search: "User directory match",
+  public_room_scan: "Public room scan",
+  message_event: "In-room message",
+};
+
 function formatAlertSurface(surface: TrustFinding["alert_surface"]): string {
-  return surface.replace(/_/g, " ");
+  switch (surface) {
+    case "admin_ui":
+      return "Admin UI only";
+    case "staff_room":
+      return "Staff room only";
+    case "both":
+      return "Admin UI + staff room";
+    case "none":
+      return "Silent (no notifications)";
+    default:
+      return surface;
+  }
 }
 
 function formatTimestamp(value: string | null): string {
@@ -31,130 +73,328 @@ function formatTimestamp(value: string | null): string {
   return new Date(value).toLocaleString();
 }
 
-export function SecurityFindingDetail({ finding, isMutating, onAction }: SecurityFindingDetailProps) {
-  if (!finding) {
-    return (
-      <div className="rounded-2xl border border-dashed border-border/70 bg-card/40 p-6 text-sm text-muted-foreground">
-        Select a finding to inspect the evidence summary and workflow actions.
-      </div>
-    );
-  }
-
-  const Icon = DETECTOR_ICONS[finding.detector_key] ?? FALLBACK_DETECTOR_ICON;
-  const displayName = finding.suspect_display_name || finding.suspect_actor_id;
-
-  return (
-    <div className="space-y-5 rounded-2xl border border-border/70 bg-card/70 p-5">
-      <div className="rounded-2xl border border-border/70 bg-gradient-to-br from-amber-500/10 via-background to-red-500/5 p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-2">
-            <div className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              <Icon className="h-3.5 w-3.5" />
-              {DETECTOR_LABELS[finding.detector_key] ?? finding.detector_key}
-            </div>
-            <div className="text-xl font-semibold tracking-tight">{displayName}</div>
-            <p className="text-sm text-muted-foreground">{finding.suspect_actor_id}</p>
-          </div>
-          <Badge variant="outline" className={cn("capitalize", STATUS_STYLES[finding.status])}>
-            {formatStatus(finding.status)}
-          </Badge>
-        </div>
-        <div className="mt-4 grid gap-3 sm:grid-cols-3">
-          <MetaCard
-            icon={<ShieldAlert className="h-3.5 w-3.5" />}
-            label="Risk score"
-            value={finding.score.toFixed(2)}
-            hint={finding.score >= 0.9 ? "Immediate review" : finding.score >= 0.75 ? "High confidence" : "Monitor closely"}
-          />
-          <MetaCard
-            icon={<BellRing className="h-3.5 w-3.5" />}
-            label="Alert fan-out"
-            value={finding.notification_count > 0 ? `${finding.notification_count}x` : "Shadow only"}
-            hint={`Last notified ${formatTimestamp(finding.last_notified_at)}`}
-          />
-          <MetaCard
-            icon={<Clock3 className="h-3.5 w-3.5" />}
-            label="Last updated"
-            value={formatTimestamp(finding.updated_at)}
-            hint={`Opened ${formatTimestamp(finding.created_at)}`}
-          />
-        </div>
-      </div>
-
-      <div className="grid gap-3 md:grid-cols-2">
-        <MetaPanel label="Room scope" value={`${finding.channel_id} · ${finding.space_id}`} />
-        <MetaPanel label="Alert destination" value={formatAlertSurface(finding.alert_surface)} />
-      </div>
-
-      <div className="rounded-xl border border-border/70 bg-background/40 p-4">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <Activity className="h-4 w-4 text-muted-foreground" />
-          Why it was flagged
-        </div>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
-          {Object.entries(finding.evidence_summary).map(([key, value]) => (
-            <div key={key} className="rounded-xl border border-border/60 bg-background/60 px-4 py-3">
-              <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                {humanizeKey(key)}
-              </div>
-              <div className="mt-2 break-words text-sm font-medium text-foreground/90">
-                {String(value)}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="rounded-xl border border-border/70 bg-background/35 p-4">
-        <div className="text-sm font-medium">Review decision</div>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Resolve for confirmed risk, mark false positive for detector misses, suppress to silence the actor temporarily, or mark benign for known safe behavior.
-        </p>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <Button size="sm" onClick={() => onAction("resolve")} disabled={isMutating}>Resolve finding</Button>
-          <Button size="sm" variant="outline" onClick={() => onAction("false-positive")} disabled={isMutating}>Mark false positive</Button>
-          <Button size="sm" variant="outline" onClick={() => onAction("suppress")} disabled={isMutating}>Suppress actor</Button>
-          <Button size="sm" variant="outline" onClick={() => onAction("mark-benign")} disabled={isMutating}>Mark benign</Button>
-        </div>
-      </div>
-    </div>
-  );
+function formatRoomScope(channelId: string, spaceId: string): string {
+  const channel = channelId === "matrix" ? "Matrix" : channelId;
+  return `${channel} · ${formatRoomIdentifier(spaceId)}`;
 }
 
-function MetaCard({
-  icon,
-  label,
-  value,
-  hint,
-}: {
-  icon: ReactNode;
-  label: string;
-  value: string;
-  hint: string;
-}) {
-  return (
-    <div className="rounded-xl border border-border/70 bg-background/50 px-4 py-3">
-      <div className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-        {icon}
-        {label}
-      </div>
-      <div className="mt-2 text-sm font-semibold text-foreground/90">{value}</div>
-      <div className="mt-1 text-xs text-muted-foreground">{hint}</div>
-    </div>
-  );
-}
-
-function MetaPanel({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl border border-border/70 bg-background/40 p-4">
-      <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">{label}</div>
-      <div className="mt-2 text-sm font-medium text-foreground/90">{value}</div>
-    </div>
-  );
+function readString(
+  evidence: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = evidence[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function humanizeKey(key: string): string {
   return key
     .replace(/_/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function riskTone(score: number): {
+  label: string;
+  className: string;
+  barClassName: string;
+} {
+  if (score >= 0.9) {
+    return {
+      label: "Immediate review",
+      className: "text-red-200",
+      barClassName: "bg-red-500",
+    };
+  }
+  if (score >= 0.75) {
+    return {
+      label: "High confidence",
+      className: "text-amber-200",
+      barClassName: "bg-amber-500",
+    };
+  }
+  return {
+    label: "Monitor closely",
+    className: "text-emerald-200",
+    barClassName: "bg-emerald-500",
+  };
+}
+
+export function SecurityFindingDetail({
+  finding,
+  isMutating,
+  onAction,
+}: SecurityFindingDetailProps) {
+  if (!finding) {
+    return (
+      <div
+        className="rounded-2xl border border-dashed border-border/70 bg-card/40 p-6 text-sm text-muted-foreground"
+        data-testid="security-finding-empty"
+      >
+        Select a finding to inspect the evidence summary and workflow actions.
+      </div>
+    );
+  }
+
+  const Icon = DETECTOR_ICONS[finding.detector_key] ?? FALLBACK_DETECTOR_ICON;
+  const evidence = finding.evidence_summary;
+  const suspectAvatar = readString(evidence, "suspect_avatar_url");
+  const staffAvatar = readString(evidence, "staff_avatar_url");
+  const matchedStaffName =
+    readString(evidence, "matched_staff_name")
+    ?? readString(evidence, "staff_display_name");
+  const detectionMethodRaw = readString(evidence, "detection_method");
+  const detectionMethod = detectionMethodRaw
+    ? DETECTION_METHOD_LABELS[detectionMethodRaw] ?? humanizeKey(detectionMethodRaw)
+    : null;
+  const displayName = finding.suspect_display_name || finding.suspect_actor_id;
+  const score = riskTone(finding.score);
+  const otherSignals = Object.entries(evidence).filter(
+    ([key]) => !STRUCTURED_KEYS.has(key),
+  );
+
+  return (
+    <div
+      className="space-y-5 rounded-2xl border border-border/70 bg-card/70 p-5"
+      data-testid="security-finding-detail"
+      data-finding-id={finding.id}
+    >
+      {/* Header: detector + status + risk score */}
+      <header className="rounded-2xl border border-border/70 bg-gradient-to-br from-amber-500/10 via-background to-red-500/5 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-2">
+            <div className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              <Icon className="h-3.5 w-3.5" />
+              {DETECTOR_LABELS[finding.detector_key] ?? finding.detector_key}
+            </div>
+            <h2 className="text-xl font-semibold tracking-tight">
+              {displayName}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {finding.suspect_actor_id}
+            </p>
+          </div>
+          <Badge
+            variant="outline"
+            className={cn("capitalize", STATUS_STYLES[finding.status])}
+          >
+            {formatStatus(finding.status)}
+          </Badge>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <div className="flex items-baseline justify-between">
+            <div className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+              <ShieldAlert className="h-3.5 w-3.5" />
+              Risk score
+            </div>
+            <div className={cn("text-sm font-semibold", score.className)}>
+              {finding.score.toFixed(2)} · {score.label}
+            </div>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-background/60">
+            <div
+              className={cn("h-full transition-all", score.barClassName)}
+              style={{ width: `${Math.min(100, finding.score * 100)}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(finding.score * 100)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+        </div>
+      </header>
+
+      {/* Identity comparison — the single most important visual signal */}
+      {(suspectAvatar || staffAvatar || matchedStaffName) ? (
+        <section aria-labelledby="finding-identity-heading" className="space-y-2">
+          <div className="flex items-center gap-2">
+            <h3
+              id="finding-identity-heading"
+              className="text-sm font-semibold text-foreground/90"
+            >
+              Identity comparison
+            </h3>
+            <span className="text-xs text-muted-foreground">
+              Suspect vs. legitimate staff
+            </span>
+          </div>
+          <AvatarComparison
+            suspectAvatarUrl={suspectAvatar}
+            suspectDisplayName={finding.suspect_display_name}
+            suspectActorId={finding.suspect_actor_id}
+            staffAvatarUrl={staffAvatar}
+            staffDisplayName={matchedStaffName}
+          />
+        </section>
+      ) : null}
+
+      {/* Why it was flagged — structured, not flat KV */}
+      <section aria-labelledby="finding-why-heading" className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          <h3
+            id="finding-why-heading"
+            className="text-sm font-semibold text-foreground/90"
+          >
+            Why it was flagged
+          </h3>
+        </div>
+
+        <dl className="grid gap-3 sm:grid-cols-2">
+          {detectionMethod ? (
+            <DataRow
+              icon={<Wand2 className="h-3.5 w-3.5" />}
+              label="Detection method"
+              value={detectionMethod}
+            />
+          ) : null}
+          {matchedStaffName ? (
+            <DataRow
+              icon={<Hash className="h-3.5 w-3.5" />}
+              label="Collides with staff name"
+              value={matchedStaffName}
+              accent
+            />
+          ) : null}
+          <DataRow
+            icon={<Megaphone className="h-3.5 w-3.5" />}
+            label="Alert destination"
+            value={formatAlertSurface(finding.alert_surface)}
+          />
+          <DataRow
+            icon={<BellRing className="h-3.5 w-3.5" />}
+            label="Alert fan-out"
+            value={
+              finding.notification_count > 0
+                ? `${finding.notification_count}× notified`
+                : "Shadow only"
+            }
+            hint={`Last notified ${formatTimestamp(finding.last_notified_at)}`}
+          />
+          <DataRow
+            icon={<Hash className="h-3.5 w-3.5" />}
+            label="Room scope"
+            value={formatRoomScope(finding.channel_id, finding.space_id)}
+          />
+          <DataRow
+            icon={<Clock3 className="h-3.5 w-3.5" />}
+            label="Last updated"
+            value={formatTimestamp(finding.updated_at)}
+            hint={`Opened ${formatTimestamp(finding.created_at)}`}
+          />
+        </dl>
+
+        {otherSignals.length > 0 ? (
+          <details className="rounded-xl border border-border/60 bg-background/40 p-3 text-xs text-muted-foreground">
+            <summary className="cursor-pointer select-none font-medium text-foreground/80">
+              Other signals ({otherSignals.length})
+            </summary>
+            <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+              {otherSignals.map(([key, value]) => (
+                <div key={key} className="rounded-lg bg-background/60 px-3 py-2">
+                  <dt className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                    {humanizeKey(key)}
+                  </dt>
+                  <dd className="mt-1 break-words text-xs text-foreground/85">
+                    {String(value)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </details>
+        ) : null}
+      </section>
+
+      {/* Review actions — primary + secondary hierarchy */}
+      <section
+        aria-labelledby="finding-actions-heading"
+        className="rounded-xl border border-border/70 bg-background/35 p-4"
+      >
+        <h3
+          id="finding-actions-heading"
+          className="text-sm font-semibold text-foreground/90"
+        >
+          Review decision
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Resolve confirmed risks. Mark benign for verified safe behavior.
+          Suppress to silence the actor temporarily. Mark false positive when
+          the detector misfired.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            onClick={() => onAction("resolve")}
+            disabled={isMutating}
+            className="bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500"
+            data-action="primary"
+          >
+            Resolve finding
+          </Button>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onAction("mark-benign")}
+              disabled={isMutating}
+            >
+              Mark benign
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onAction("suppress")}
+              disabled={isMutating}
+            >
+              Suppress actor
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onAction("false-positive")}
+              disabled={isMutating}
+            >
+              False positive
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+interface DataRowProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  hint?: string;
+  accent?: boolean;
+}
+
+function DataRow({ icon, label, value, hint, accent }: DataRowProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border px-4 py-3",
+        accent
+          ? "border-amber-500/40 bg-amber-500/10"
+          : "border-border/60 bg-background/50",
+      )}
+    >
+      <dt className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+        {icon}
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          "mt-2 text-sm font-medium",
+          accent ? "text-amber-100" : "text-foreground/90",
+        )}
+      >
+        {value}
+      </dd>
+      {hint ? (
+        <p className="mt-1 text-xs text-muted-foreground">{hint}</p>
+      ) : null}
+    </div>
+  );
 }

--- a/web/src/components/admin/security/SecurityFindingsList.tsx
+++ b/web/src/components/admin/security/SecurityFindingsList.tsx
@@ -8,6 +8,7 @@ import {
   DETECTOR_LABELS,
   FALLBACK_DETECTOR_ICON,
   formatRelativeTime,
+  formatRoomIdentifier,
   formatStatus,
   STATUS_STYLES,
 } from "@/components/admin/security/securityUi";
@@ -98,7 +99,9 @@ function FindingListItem({
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <span>{finding.channel_id}</span>
             <span>•</span>
-            <span className="truncate">{finding.space_id}</span>
+            <span className="truncate" title={finding.space_id}>
+              {formatRoomIdentifier(finding.space_id)}
+            </span>
           </div>
           <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <span className={cn("font-medium", scoreTone(finding.score))}>

--- a/web/src/components/admin/security/securityUi.test.ts
+++ b/web/src/components/admin/security/securityUi.test.ts
@@ -1,0 +1,27 @@
+import { formatRoomIdentifier } from "@/components/admin/security/securityUi";
+
+describe("formatRoomIdentifier", () => {
+  it("renders a friendly label for proactive scans", () => {
+    expect(formatRoomIdentifier("proactive_scan")).toBe("proactive scan");
+  });
+
+  it("falls back when missing", () => {
+    expect(formatRoomIdentifier(null)).toBe("(unknown room)");
+    expect(formatRoomIdentifier(undefined)).toBe("(unknown room)");
+    expect(formatRoomIdentifier("")).toBe("(unknown room)");
+  });
+
+  it("truncates long Matrix room IDs but keeps the homeserver", () => {
+    expect(formatRoomIdentifier("!ilodKeOTMMMDTlGhkf:matrix.org")).toBe(
+      "!ilodKeOT…:matrix.org",
+    );
+  });
+
+  it("leaves short room IDs alone", () => {
+    expect(formatRoomIdentifier("!short:matrix.org")).toBe("!short:matrix.org");
+  });
+
+  it("passes non-room strings through unchanged", () => {
+    expect(formatRoomIdentifier("custom-space")).toBe("custom-space");
+  });
+});

--- a/web/src/components/admin/security/securityUi.ts
+++ b/web/src/components/admin/security/securityUi.ts
@@ -33,6 +33,35 @@ export function formatStatus(status: TrustFinding["status"]): string {
   return status.replace(/_/g, " ");
 }
 
+/**
+ * Render a Matrix-ish space identifier in a way that is readable in the
+ * admin UI. Full IDs are noisy (`!ilodKeOTMMMDTlGhkf:matrix.org`) but we
+ * cannot resolve them to display names without a backend round-trip.
+ *
+ * Strategy:
+ * - "proactive_scan"            → "proactive scan"
+ * - empty/null                  → "(unknown room)"
+ * - long Matrix room IDs        → "!ilodKeO…:matrix.org"
+ * - everything else             → returned unchanged
+ */
+export function formatRoomIdentifier(spaceId: string | null | undefined): string {
+  if (!spaceId) {
+    return "(unknown room)";
+  }
+  if (spaceId === "proactive_scan") {
+    return "proactive scan";
+  }
+  if (spaceId.startsWith("!")) {
+    const colonIndex = spaceId.indexOf(":");
+    if (colonIndex > 9) {
+      const head = spaceId.slice(0, 9);
+      const tail = spaceId.slice(colonIndex);
+      return `${head}…${tail}`;
+    }
+  }
+  return spaceId;
+}
+
 export function formatRelativeTime(value: string): string {
   const diffMs = Date.now() - new Date(value).getTime();
   const diffMinutes = Math.max(0, Math.floor(diffMs / 60000));

--- a/web/src/lib/__tests__/matrix-media.test.ts
+++ b/web/src/lib/__tests__/matrix-media.test.ts
@@ -47,10 +47,9 @@ describe("resolveAvatarUrl", () => {
     expect(url).toContain("abc%25foo");
   });
 
-  it("passes through https URLs unchanged", () => {
-    expect(resolveAvatarUrl("https://example.com/a.png")).toBe(
-      "https://example.com/a.png",
-    );
+  it("rejects raw https URLs to prevent third-party tracking of admin viewers", () => {
+    expect(resolveAvatarUrl("https://example.com/a.png")).toBeNull();
+    expect(resolveAvatarUrl("http://example.com/a.png")).toBeNull();
   });
 
   it("returns null for unsupported schemes and empty input", () => {

--- a/web/src/lib/__tests__/matrix-media.test.ts
+++ b/web/src/lib/__tests__/matrix-media.test.ts
@@ -1,0 +1,61 @@
+import { parseMxcUri, resolveAvatarUrl } from "@/lib/matrix-media";
+
+describe("parseMxcUri", () => {
+  it("parses a well-formed mxc URI", () => {
+    expect(parseMxcUri("mxc://matrix.org/abcDEF123")).toEqual({
+      serverName: "matrix.org",
+      mediaId: "abcDEF123",
+    });
+  });
+
+  it("returns null for null/undefined/empty", () => {
+    expect(parseMxcUri(null)).toBeNull();
+    expect(parseMxcUri(undefined)).toBeNull();
+    expect(parseMxcUri("")).toBeNull();
+  });
+
+  it("returns null for non-mxc URLs", () => {
+    expect(parseMxcUri("https://matrix.org/abc")).toBeNull();
+    expect(parseMxcUri("abc")).toBeNull();
+  });
+
+  it("returns null when the media id is missing", () => {
+    expect(parseMxcUri("mxc://matrix.org/")).toBeNull();
+    expect(parseMxcUri("mxc://matrix.org")).toBeNull();
+  });
+
+  it("returns null when the server is missing", () => {
+    expect(parseMxcUri("mxc:///abc")).toBeNull();
+  });
+
+  it("rejects nested paths", () => {
+    expect(parseMxcUri("mxc://matrix.org/foo/bar")).toBeNull();
+  });
+});
+
+describe("resolveAvatarUrl", () => {
+  it("converts mxc URIs to a backend proxy path", () => {
+    const url = resolveAvatarUrl("mxc://matrix.org/abcDEF123");
+    expect(url).toMatch(
+      /\/admin\/security\/matrix-media\/matrix\.org\/abcDEF123$/,
+    );
+  });
+
+  it("escapes special characters in segments", () => {
+    const url = resolveAvatarUrl("mxc://matrix.org/abc%foo");
+    // "%" must be percent-encoded by encodeURIComponent
+    expect(url).toContain("abc%25foo");
+  });
+
+  it("passes through https URLs unchanged", () => {
+    expect(resolveAvatarUrl("https://example.com/a.png")).toBe(
+      "https://example.com/a.png",
+    );
+  });
+
+  it("returns null for unsupported schemes and empty input", () => {
+    expect(resolveAvatarUrl(null)).toBeNull();
+    expect(resolveAvatarUrl("")).toBeNull();
+    expect(resolveAvatarUrl("ftp://x/y")).toBeNull();
+  });
+});

--- a/web/src/lib/matrix-media.ts
+++ b/web/src/lib/matrix-media.ts
@@ -34,22 +34,16 @@ export function parseMxcUri(uri: string | null | undefined): ParsedMxc | null {
 }
 
 /**
- * Convert any avatar URL into something an `<img src=…>` can load.
+ * Convert a Matrix `mxc://` URI into a backend proxy URL the admin UI
+ * can render via `<img src=…>`.
  *
- * - `mxc://server/id` → backend proxy URL
- * - `https://…`       → returned unchanged (already loadable)
- * - everything else   → null (caller should render the fallback)
+ * Only `mxc://` is accepted. Raw `https?://` URLs are intentionally
+ * rejected so untrusted third parties cannot track admin viewers.
  */
 export function resolveAvatarUrl(url: string | null | undefined): string | null {
-  if (!url) {
+  const parsed = parseMxcUri(url);
+  if (!parsed) {
     return null;
   }
-  const parsed = parseMxcUri(url);
-  if (parsed) {
-    return `${API_BASE_URL}/admin/security/matrix-media/${encodeURIComponent(parsed.serverName)}/${encodeURIComponent(parsed.mediaId)}`;
-  }
-  if (url.startsWith("https://") || url.startsWith("http://")) {
-    return url;
-  }
-  return null;
+  return `${API_BASE_URL}/admin/security/matrix-media/${encodeURIComponent(parsed.serverName)}/${encodeURIComponent(parsed.mediaId)}`;
 }

--- a/web/src/lib/matrix-media.ts
+++ b/web/src/lib/matrix-media.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for converting Matrix `mxc://` URIs into URLs the admin UI can
+ * render. The actual download is proxied by the FastAPI backend so the
+ * Matrix access token never reaches the browser.
+ */
+
+import { API_BASE_URL } from "@/lib/config";
+
+const MXC_PREFIX = "mxc://";
+
+export interface ParsedMxc {
+  serverName: string;
+  mediaId: string;
+}
+
+export function parseMxcUri(uri: string | null | undefined): ParsedMxc | null {
+  if (!uri || typeof uri !== "string") {
+    return null;
+  }
+  if (!uri.startsWith(MXC_PREFIX)) {
+    return null;
+  }
+  const remainder = uri.slice(MXC_PREFIX.length);
+  const slashIndex = remainder.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === remainder.length - 1) {
+    return null;
+  }
+  const serverName = remainder.slice(0, slashIndex);
+  const mediaId = remainder.slice(slashIndex + 1);
+  if (mediaId.includes("/")) {
+    return null;
+  }
+  return { serverName, mediaId };
+}
+
+/**
+ * Convert any avatar URL into something an `<img src=…>` can load.
+ *
+ * - `mxc://server/id` → backend proxy URL
+ * - `https://…`       → returned unchanged (already loadable)
+ * - everything else   → null (caller should render the fallback)
+ */
+export function resolveAvatarUrl(url: string | null | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  const parsed = parseMxcUri(url);
+  if (parsed) {
+    return `${API_BASE_URL}/admin/security/matrix-media/${encodeURIComponent(parsed.serverName)}/${encodeURIComponent(parsed.mediaId)}`;
+  }
+  if (url.startsWith("https://") || url.startsWith("http://")) {
+    return url;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Honor `policy.alert_surface` in proactive findings (the proactive scanner was hardcoding `BOTH`, bypassing the operator's `admin_ui` policy and posting to the staff room anyway).
- Render real Matrix avatars in the admin Security Alerts page so impersonation cases are visible at a glance instead of being hidden behind raw `mxc://` URLs.
- Restructure the finding detail panel with a clearer hierarchy and primary-action emphasis; fix flickering when clicking findings.
- Rewrite the staff-room alert format to be scannable and stop the "Unable to load event that was replied to" message in Matrix clients.

## Backend

- `proactive_persistence.py` (new): pure persister, reads `policy.alert_surface` and overrides whatever the detector produced. Unit-tested with a fake policy service and store. Wired in via `_handle_proactive_finding` in `main.py`.
- `matrix_media_proxy.py` + `GET /admin/security/matrix-media/{server}/{media_id}` (new): backend-only proxy so the Matrix access token never leaves the API. Tries the authenticated v1 endpoint, falls back to legacy v3, validates segments to prevent path traversal, caps payloads at 2 MB. Reuses an app-scoped `httpx.AsyncClient` registered in lifespan and closed on shutdown.
- `alert_formatting.py` (new): renders Matrix staff-room alerts as scannable markdown with bold sections, friendly detector labels, and no `mxc://` URLs (clients can't render them inline). The notifier in `main.py` now passes `in_reply_to=""`, which suppresses the bogus `m.in_reply_to` relation that was producing "Unable to load event that was replied to".

## Frontend

- `MatrixAvatar` and `AvatarComparison`: new components that render the suspect and the legitimate staff member side by side via the backend media proxy. Plain `<img>` with `onError` fallback to initials.
- `SecurityFindingDetail` rewrite:
  - Identity comparison block at the top
  - Risk score progress bar with semantic color tone
  - Structured "Why it was flagged" with labeled rows (detection method, collides with staff name, alert destination, fan-out, room scope, last updated)
  - Collapsible "Other signals" `<details>` for non-structured evidence
  - Primary red Resolve button + grouped secondary actions
- `formatRoomIdentifier`: truncates noisy room IDs (`!ilodKeOTMMMDTlGhkf:matrix.org` → `!ilodKeOT…:matrix.org`) in both the detail panel and the findings list, with the full ID in the `title` attribute.
- Flicker fix in `SecurityAlertsClient`: selection state moved out of the Next.js URL (which forces a server-component refetch on every click) and into local state with `window.history.replaceState`. Verified via Playwright that clicking a finding does not trigger a new server fetch and the detail panel ref does not unmount.

## Tests

- 31 backend unit tests (persister policy override, media proxy fetcher with fake httpx client, alert formatter)
- 35 web tests (avatar components, mxc URI helpers, room identifier formatter, structured detail panel)
- All 194 web tests + the relevant 31 backend tests green

## Test plan

- [ ] CI green on this PR
- [ ] Open `/admin/security/alerts` and confirm the suspect/staff avatars render via the proxy
- [ ] Click a finding and confirm the detail panel does not flicker
- [ ] Resolve a finding and confirm the action button works
- [ ] Trigger a new proactive finding (or wait for one) and confirm the staff-room alert renders cleanly without "Unable to load event that was replied to"
- [ ] Confirm the alert respects `TRUST_MONITOR_ALERT_SURFACE=admin_ui` (no Matrix delivery when policy is admin-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved Matrix alert formatting for trust monitor staff notifications
  * Added avatar comparison interface to visualize suspect vs. legitimate staff avatars in security findings
  * Added Matrix media proxy to load and cache avatars from Matrix homeservers

* **Improvements**
  * Enhanced security finding details with structured evidence sections and human-readable labels
  * Improved room identifier formatting in admin security UI

* **Tests**
  * Added comprehensive test coverage for alert formatting, persistence, media proxy, and UI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->