### PR TITLE
Stop posting scam warnings into the public support room

### DIFF
--- a/api/app/channels/trust_monitor/proactive_scanner.py
+++ b/api/app/channels/trust_monitor/proactive_scanner.py
@@ -4,17 +4,16 @@ Periodically searches the Matrix user directory and public room directory
 for potential impersonation of Bisq staff. Creates trust findings when
 suspicious accounts or rooms are discovered.
 
-Capabilities:
-1. User directory scan — finds accounts with display names matching staff
-2. Public room directory scan — finds rooms with Bisq-related names
-3. Educational warning — posts scam warnings when name collisions are found
+Findings are forwarded via the `on_finding` callback, which routes them
+to the admin UI (always) and the staff room (when the operator policy
+allows). The scanner itself never posts into the observed public rooms.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 
 import aiohttp
@@ -24,14 +23,6 @@ from app.channels.trust_monitor.detectors.staff_name_collision import (
     normalize_display_name,
 )
 from app.channels.trust_monitor.models import TrustAlertSurface
-
-try:
-    from nio import RoomSendResponse
-
-    _NIO_AVAILABLE = True
-except ImportError:
-    _NIO_AVAILABLE = False
-    RoomSendResponse = None
 
 logger = logging.getLogger(__name__)
 
@@ -47,16 +38,6 @@ _BISQ_ROOM_KEYWORDS = [
 
 # Subset used for the "suspicious room name" filter
 _SUSPICIOUS_ROOM_TERMS = ["bisq support", "bisq help", "bisq easy"]
-
-_SCAM_WARNING = (
-    "\u26a0\ufe0f **Security Notice**: Official Bisq support staff will **NEVER** send "
-    "you a direct message first. If someone DMs you claiming to be Bisq support, "
-    "**do not share your seed phrase, passwords, or send any funds**. "
-    "Report suspicious accounts to the room moderators."
-)
-
-# Minimum interval between scam warnings per room (24 hours)
-_WARNING_COOLDOWN = timedelta(hours=24)
 
 
 class ProactiveImpersonationScanner:
@@ -91,7 +72,6 @@ class ProactiveImpersonationScanner:
         self._running = False
         self._reported_user_ids: set[str] = set()
         self._reported_room_ids: set[str] = set()
-        self._last_warning_per_room: dict[str, datetime] = {}
 
     async def start(self) -> None:
         if self._running:
@@ -147,9 +127,6 @@ class ProactiveImpersonationScanner:
                     self.on_finding(finding)
                 except Exception:
                     logger.warning("on_finding callback failed", exc_info=True)
-
-        if user_findings:
-            await self._post_scam_warning()
 
     # ------------------------------------------------------------------
     # User directory scanning
@@ -349,36 +326,3 @@ class ProactiveImpersonationScanner:
                 except Exception:
                     pass
         return None
-
-    # ------------------------------------------------------------------
-    # Educational warning (rate-limited per room)
-    # ------------------------------------------------------------------
-
-    async def _post_scam_warning(self) -> None:
-        """Post a scam warning in monitored rooms (max once per 24h per room)."""
-        if self.matrix_client is None or not _NIO_AVAILABLE:
-            return
-
-        now = datetime.now(UTC)
-        for room_id in self.monitored_room_ids:
-            last = self._last_warning_per_room.get(room_id)
-            if last is not None and (now - last) < _WARNING_COOLDOWN:
-                continue
-
-            try:
-                resp = await self.matrix_client.room_send(
-                    room_id=room_id,
-                    message_type="m.room.message",
-                    content={"msgtype": "m.notice", "body": _SCAM_WARNING},
-                )
-                if isinstance(resp, RoomSendResponse):
-                    self._last_warning_per_room[room_id] = now
-                    logger.info("Posted scam warning to %s", room_id)
-                else:
-                    logger.warning(
-                        "Failed to post scam warning to %s: %s", room_id, resp
-                    )
-            except Exception:
-                logger.warning(
-                    "Error posting scam warning to %s", room_id, exc_info=True
-                )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -160,7 +160,7 @@ httpx-sse==0.4.3
     # via
     #   langchain-community
     #   mcp
-huggingface-hub==1.10.1
+huggingface-hub==1.10.2
     # via
     #   datasets
     #   tokenizers
@@ -243,7 +243,7 @@ langgraph-prebuilt==1.0.9
     # via langgraph
 langgraph-sdk==0.3.13
     # via langgraph
-langsmith==0.7.30
+langsmith==0.7.31
     # via
     #   langchain-classic
     #   langchain-community

--- a/api/tests/channels/trust_monitor/test_proactive_scanner.py
+++ b/api/tests/channels/trust_monitor/test_proactive_scanner.py
@@ -1,0 +1,77 @@
+"""Regression tests for ProactiveImpersonationScanner side-effects.
+
+The scanner must never post messages into the public observed rooms —
+they are read-only. Staff-room delivery is handled exclusively by the
+`CompositeTrustAlertPublisher.matrix_notifier` path, which honors the
+operator policy.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from app.channels.trust_monitor.detectors.base import DetectorResult
+from app.channels.trust_monitor.models import TrustAlertSurface
+from app.channels.trust_monitor.proactive_scanner import (
+    ProactiveImpersonationScanner,
+)
+
+
+def _make_result() -> DetectorResult:
+    return DetectorResult(
+        detector_key="proactive_user_impersonation",
+        suspect_actor_id="@bad:matrix.org",
+        suspect_actor_key="@bad:matrix.org",
+        suspect_display_name="suddenwhipvapor",
+        score=0.95,
+        evidence_summary={"matched_staff_name": "suddenwhipvapor"},
+        alert_surface=TrustAlertSurface.BOTH,
+        occurred_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_scanner_never_posts_into_monitored_public_rooms() -> None:
+    matrix_client = SimpleNamespace(
+        room_send=AsyncMock(),
+        access_token="syt_test",
+    )
+    scanner = ProactiveImpersonationScanner(
+        homeserver_url="https://matrix.org",
+        access_token="syt_test",
+        staff_resolver=SimpleNamespace(get_display_names=lambda: set()),
+        trusted_staff_ids=set(),
+        monitored_room_ids={"!kAbNUeIFukYxWXxyFY:bitcoin.kyoto"},
+        matrix_client=matrix_client,
+        on_finding=lambda _finding: None,
+    )
+    scanner._scan_user_directory = AsyncMock(return_value=[_make_result()])  # type: ignore[method-assign]
+    scanner._scan_public_rooms = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    await scanner._run_scans()
+
+    matrix_client.room_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_scanner_forwards_findings_via_on_finding_callback() -> None:
+    captured: list[DetectorResult] = []
+    scanner = ProactiveImpersonationScanner(
+        homeserver_url="https://matrix.org",
+        access_token="syt_test",
+        staff_resolver=SimpleNamespace(get_display_names=lambda: set()),
+        trusted_staff_ids=set(),
+        monitored_room_ids={"!room:matrix.org"},
+        matrix_client=SimpleNamespace(room_send=AsyncMock()),
+        on_finding=captured.append,
+    )
+    result = _make_result()
+    scanner._scan_user_directory = AsyncMock(return_value=[result])  # type: ignore[method-assign]
+    scanner._scan_public_rooms = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    await scanner._run_scans()
+
+    assert captured == [result]


### PR DESCRIPTION
## Summary

The proactive impersonation scanner was unconditionally calling `matrix_client.room_send` into every room in `MATRIX_SYNC_ROOMS` whenever a scan cycle produced a finding — attempting to post an end-user anti-scam PSA. On production that room is the bitcoin.kyoto Bisq Support room, which is observe-only: the alert bot is there to monitor, not to participate. Every successful scan cycle produced this in `docker logs api`:

```
WARNING app.channels.trust_monitor.proactive_scanner: Error posting scam warning to !kAbNUeIFukYxWXxyFY:bitcoin.kyoto
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/nio/client/async_client.py", line 1789, in room_send
    room = self.rooms[room_id]
KeyError: '!kAbNUeIFukYxWXxyFY:bitcoin.kyoto'
…
nio.exceptions.LocalProtocolError: No such room with id !kAbNUeIFukYxWXxyFY:bitcoin.kyoto found.
```

## Why delete instead of retarget

Staff-room delivery for findings is already handled by `CompositeTrustAlertPublisher.matrix_notifier`, wired up in `main.py` via `_notify_staff_room`. That path:

1. Honors `policy.alert_surface` (currently `admin_ui` → staff room silent; flip to `both` → delivered to `!FtekSajHOJmxCkISRg:matrix.org` too)
2. Renders the staff-oriented alert via `format_trust_alert_for_matrix` (bold sections, scannable, no raw `mxc://` URLs)
3. Was fixed in #174 to use the policy surface rather than the detector's hardcoded `BOTH`

The old public-room PSA text (*"Official Bisq support staff will NEVER DM you first…"*) was written for end users who might be victims, **not** for staff. Retargeting it to the staff room would be redundant with the existing notifier path and the content is wrong for the audience. Deleting is the correct fix.

The intent as confirmed with the user:
- **Public support room** (`!kAbNUeIFukYxWXxyFY:bitcoin.kyoto`) → observe only, **never** post
- **Admin UI** → **always** shows findings (handled by `persist_proactive_finding` → `store.upsert_finding`)
- **Bisq Support Staff room** (`!FtekSajHOJmxCkISRg:matrix.org`) → gets the finding **additionally** when `policy.alert_surface` allows it (handled by the Composite publisher)

## Changes

- Remove `_post_scam_warning` method and its call in `_run_scans`.
- Remove `_SCAM_WARNING`, `_WARNING_COOLDOWN`, `_last_warning_per_room` state, and the now-unused nio `RoomSendResponse` import.
- Update the module docstring to reflect that the scanner never posts into the observed rooms.
- Add `test_proactive_scanner.py` regression tests asserting:
  - `matrix_client.room_send` is **never** called during a scan cycle that produces a finding
  - Findings are still forwarded via the `on_finding` callback

## Test plan

- [x] `pytest tests/channels/trust_monitor/ -q` → 33 passed
- [x] Full pre-commit suite → 704 passed
- [x] Local API restart → clean startup, `Application startup complete`, no `scam` references, scanner started with interval=900s
- [ ] CI green on this PR
- [ ] Post-deploy: verify prod logs show no more `Error posting scam warning …` tracebacks after the next scan cycle (~15 min)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified scanner to deliver findings exclusively through callback mechanism instead of posting warnings directly to monitored public rooms.

* **Tests**
  * Added regression tests verifying callback delivery of findings and confirming scanner does not post messages to monitored rooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->