### PR TITLE
Harden Bisq readiness monitoring

### DIFF
--- a/docker/alertmanager/alertmanager.yml
+++ b/docker/alertmanager/alertmanager.yml
@@ -68,4 +68,4 @@ receivers:
   - name: 'matrix-warnings'
     webhook_configs:
       - url: 'http://api:8000/alertmanager/alerts'
-        send_resolved: false
+        send_resolved: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -505,6 +505,9 @@ services:
       - HEALTHCHECK_URL=${HEALTHCHECK_URL:-https://hc-ping.com/27867359-f4f3-4e22-8f46-8d18a73cf219}
       - ADMIN_API_KEY=${ADMIN_API_KEY}
       - API_HOST=api
+      - API_PORT=8000
+      - BISQ_READINESS_CURRENCY=${BISQ_READINESS_CURRENCY:-EUR}
+      - BISQ_READINESS_DIRECTION=${BISQ_READINESS_DIRECTION:-SELL}
     volumes:
       - ./scripts:/scripts:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -515,11 +518,13 @@ services:
         mkdir -p /var/log/cron &&
         # Add @reboot entries to run scripts once when crond starts
         echo '@reboot /scripts/process-feedback.sh >> /var/log/cron/feedback.log 2>&1' > /etc/crontabs/root &&
+        echo '@reboot /scripts/bisq-readiness-check.sh >> /var/log/cron/bisq-readiness.log 2>&1' >> /etc/crontabs/root &&
         # Add regular cron entries
         # NOTE: update-faqs.sh removed - replaced by unified training pipeline (poll-matrix.sh)
         echo '0 1 * * 0 /scripts/update-wiki.sh >> /var/log/cron/wiki.log 2>&1' >> /etc/crontabs/root &&
         echo '0 0 * * 1 /scripts/process-feedback.sh >> /var/log/cron/feedback.log 2>&1' >> /etc/crontabs/root &&
         echo '*/15 * * * * /scripts/rag-health-check.sh >> /var/log/cron/rag-health.log 2>&1' >> /etc/crontabs/root &&
+        echo '*/10 * * * * /scripts/bisq-readiness-check.sh >> /var/log/cron/bisq-readiness.log 2>&1' >> /etc/crontabs/root &&
         echo '0 */12 * * * /scripts/poll-matrix.sh >> /var/log/cron/matrix-poll.log 2>&1' >> /etc/crontabs/root &&
         # Start cron daemon in foreground, logging verbosely to stderr (which goes to docker logs)
         crond -f -l 8 -d 8

--- a/docker/scripts/bisq-readiness-check.sh
+++ b/docker/scripts/bisq-readiness-check.sh
@@ -48,7 +48,10 @@ call_mcp_tool() {
         return 1
     fi
 
-    error_message=$(echo "$response" | jq -r '.error.message // empty')
+    if ! error_message=$(echo "$response" | jq -r '.error.message // empty' 2>/dev/null); then
+        log "FAIL: $tool_name returned non-JSON response"
+        return 1
+    fi
     if [ -n "$error_message" ]; then
         log "FAIL: $tool_name returned MCP error: $error_message"
         return 1

--- a/docker/scripts/bisq-readiness-check.sh
+++ b/docker/scripts/bisq-readiness-check.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo pipefail
+
+# Refresh Bisq live-data readiness metrics inside the API process.
+#
+# The Prometheus BisqReadinessChecksStale alert watches the timestamp that is
+# updated by MCP live-data probes. Calling the existing internal MCP endpoint
+# keeps that timestamp fresh without adding another public API route.
+
+LOG_PREFIX="[Bisq Readiness Check]"
+API_HOST="${API_HOST:-api}"
+API_PORT="${API_PORT:-8000}"
+API_URL="${BISQ_READINESS_API_URL:-http://${API_HOST}:${API_PORT}}"
+BISQ_READINESS_CURRENCY="${BISQ_READINESS_CURRENCY:-EUR}"
+BISQ_READINESS_DIRECTION="${BISQ_READINESS_DIRECTION:-SELL}"
+CURL_TIMEOUT="${BISQ_READINESS_TIMEOUT_SECONDS:-30}"
+
+log() {
+    echo "$LOG_PREFIX $(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+call_mcp_tool() {
+    local tool_name="$1"
+    local args_json="$2"
+    local payload
+    local response
+    local error_message
+    local content_prefix
+
+    payload=$(jq -n \
+        --arg tool_name "$tool_name" \
+        --argjson args "$args_json" \
+        '{
+            jsonrpc: "2.0",
+            id: $tool_name,
+            method: "tools/call",
+            params: {
+                name: $tool_name,
+                arguments: $args
+            }
+        }')
+
+    if ! response=$(curl -fsS --max-time "$CURL_TIMEOUT" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "$API_URL/mcp"); then
+        log "FAIL: $tool_name request failed"
+        return 1
+    fi
+
+    error_message=$(echo "$response" | jq -r '.error.message // empty')
+    if [ -n "$error_message" ]; then
+        log "FAIL: $tool_name returned MCP error: $error_message"
+        return 1
+    fi
+
+    if ! echo "$response" | jq -e '.result.content[0].text | type == "string" and length > 0' >/dev/null; then
+        log "FAIL: $tool_name returned no text content"
+        return 1
+    fi
+
+    content_prefix=$(echo "$response" | jq -r '.result.content[0].text' | tr '\n' ' ' | cut -c 1-140)
+    log "PASS: $tool_name refreshed readiness metrics (${content_prefix})"
+}
+
+main() {
+    local failures=0
+    local market_args
+    local offerbook_args
+
+    log "Starting Bisq readiness check via $API_URL/mcp"
+
+    market_args=$(jq -n --arg currency "$BISQ_READINESS_CURRENCY" '{currency: $currency}')
+    offerbook_args=$(jq -n \
+        --arg currency "$BISQ_READINESS_CURRENCY" \
+        --arg direction "$BISQ_READINESS_DIRECTION" \
+        '{currency: $currency, direction: $direction}')
+
+    call_mcp_tool "get_market_prices" "$market_args" || failures=$((failures + 1))
+    call_mcp_tool "get_offerbook" "$offerbook_args" || failures=$((failures + 1))
+
+    if [ "$failures" -gt 0 ]; then
+        log "Bisq readiness check failed ($failures probe failure(s))"
+        return 1
+    fi
+
+    log "Bisq readiness check complete"
+}
+
+main "$@"

--- a/scripts/lib/docker-utils.sh
+++ b/scripts/lib/docker-utils.sh
@@ -312,7 +312,7 @@ rebuild_services() {
     log_info "Ensuring monitoring services are running..."
     # Start all monitoring services (if defined in compose file)
     # These services enhance observability; graceful degradation if unavailable
-    local monitoring_services=("prometheus" "grafana" "node-exporter" "alertmanager" "cadvisor" "scheduler" "matrix-alertmanager-webhook")
+    local monitoring_services=("prometheus" "grafana" "node-exporter" "alertmanager" "cadvisor" "scheduler")
     local monitoring_failed=0
     for svc in "${monitoring_services[@]}"; do
         if docker compose -f "$compose_file" up -d "$svc" 2>/dev/null; then
@@ -438,7 +438,7 @@ check_and_repair_services() {
     local failed_services=()
     # All core and monitoring services are critical for production operation
     local critical_services=("api" "web" "nginx" "prometheus" "grafana" "node-exporter" "scheduler" "alertmanager")
-    local all_services=("nginx" "web" "api" "bisq2-api" "prometheus" "grafana" "node-exporter" "scheduler" "alertmanager" "cadvisor" "matrix-alertmanager-webhook")
+    local all_services=("nginx" "web" "api" "bisq2-api" "prometheus" "grafana" "node-exporter" "scheduler" "alertmanager" "cadvisor")
 
     if uses_qdrant_runtime; then
         critical_services=("qdrant" "${critical_services[@]}")


### PR DESCRIPTION
## Summary
- Add a scheduled internal Bisq readiness probe that calls the existing MCP live-data tools every 10 minutes.
- Send resolved Matrix notifications for warning alerts so support staff can see when a warning recovered.
- Remove the deleted `matrix-alertmanager-webhook` service from deploy health expectations.

## Root Cause
`BisqReadinessChecksStale` watches `bisq2_api_last_check_timestamp`, but production only refreshed that timestamp during startup/live-data calls. After deploy validation, the metric went stale again because no scheduled job refreshed the MCP live-data probes.

Warning alerts also used `send_resolved: false`, so Matrix showed warning firings without recovery messages.

## Validation
- `bash -n docker/scripts/bisq-readiness-check.sh scripts/lib/docker-utils.sh`
- Mocked `docker/scripts/bisq-readiness-check.sh` execution with a fake `curl` response
- `docker compose -f docker/docker-compose.yml config --services`
- `pre-commit run --files docker/scripts/bisq-readiness-check.sh docker/docker-compose.yml docker/alertmanager/alertmanager.yml scripts/lib/docker-utils.sh`
- Production read-only checks confirmed `BisqApiAuthFailures` is not firing and has no increase in the last hour.
- Production MCP probes for `get_market_prices` and `get_offerbook` succeeded and refreshed the readiness timestamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bisq readiness monitoring that runs periodically to check system health status.

* **Bug Fixes**
  * Enabled alertmanager to send notifications when alerts are resolved.

* **Chores**
  * Updated Docker service configuration and monitoring assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->