### PR TITLE
[codex] Clarify knowledge update review flow

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,249 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-11T00:00:00.000Z",
+  "title": "Design System: Bisq 2 Support Agent",
+  "extensions": {
+    "colorMeta": {
+      "background": {
+        "role": "neutral",
+        "displayName": "Paper Background",
+        "canonical": "hsl(0 0% 100%)",
+        "tonalRamp": ["#262626", "#3f3f3f", "#737373", "#a3a3a3", "#d4d4d4", "#e5e5e5", "#f5f5f5", "#ffffff"]
+      },
+      "foreground": {
+        "role": "neutral",
+        "displayName": "Ink Foreground",
+        "canonical": "hsl(0 0% 3.9%)",
+        "tonalRamp": ["#0a0a0a", "#171717", "#262626", "#404040", "#525252", "#737373", "#a3a3a3", "#d4d4d4"]
+      },
+      "primary-green": {
+        "role": "primary",
+        "displayName": "Bisq Support Green",
+        "canonical": "hsl(127 65% 42%)",
+        "tonalRamp": ["#052e0b", "#0b4d14", "#126b1f", "#18892a", "#25b13c", "#51c364", "#90dc9d", "#d8f3dc"]
+      },
+      "secondary-green-surface": {
+        "role": "secondary",
+        "displayName": "Quiet Green Surface",
+        "canonical": "hsl(127 25% 96%)",
+        "tonalRamp": ["#142318", "#233b29", "#3d6144", "#64846b", "#9db7a3", "#c9d8cc", "#e6efe8", "#f2f7f3"]
+      },
+      "accent-green-surface": {
+        "role": "secondary",
+        "displayName": "Accent Green Surface",
+        "canonical": "hsl(127 35% 90%)",
+        "tonalRamp": ["#102917", "#1d4326", "#356b40", "#5b9365", "#91bd99", "#c1ddc6", "#dceddf", "#f2f8f3"]
+      },
+      "border-green-gray": {
+        "role": "neutral",
+        "displayName": "Green-Gray Border",
+        "canonical": "hsl(127 15% 89%)",
+        "tonalRamp": ["#1b211c", "#303a32", "#526056", "#7c8b80", "#a8b5ab", "#c8d0ca", "#dee5df", "#f1f5f2"]
+      },
+      "destructive-red": {
+        "role": "semantic",
+        "displayName": "Destructive Red",
+        "canonical": "hsl(0 84.2% 60.2%)",
+        "tonalRamp": ["#450a0a", "#7f1d1d", "#991b1b", "#dc2626", "#ef4444", "#f87171", "#fecaca", "#fef2f2"]
+      },
+      "bisq-orange": {
+        "role": "brand-accent",
+        "displayName": "Bisq Orange Progress",
+        "canonical": "#f7931a",
+        "tonalRamp": ["#431407", "#7c2d12", "#9a3412", "#c2410c", "#f7931a", "#fb923c", "#fed7aa", "#fff7ed"]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Admin Page Title",
+        "purpose": "Major route headings and high-level page titles."
+      },
+      "headline": {
+        "displayName": "Section Headline",
+        "purpose": "Dashboard and page section headings."
+      },
+      "title": {
+        "displayName": "Panel Title",
+        "purpose": "Cards, queue items, decision panels, and review regions."
+      },
+      "body": {
+        "displayName": "Operational Body",
+        "purpose": "Default text for admin work, chat markdown, explanations, and form copy."
+      },
+      "label": {
+        "displayName": "Compact Label",
+        "purpose": "Badges, metadata, counts, status chips, and keyboard hints."
+      }
+    },
+    "shadows": [
+      {
+        "name": "card-resting",
+        "value": "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        "purpose": "Default shadcn card separation for primary panels."
+      },
+      {
+        "name": "control-subtle",
+        "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+        "purpose": "Small button and input separation when borders are not enough."
+      }
+    ],
+    "motion": [
+      {
+        "name": "state-fast",
+        "value": "150ms ease-out",
+        "purpose": "Button, badge, hover, and focus feedback."
+      },
+      {
+        "name": "collapse-standard",
+        "value": "250ms cubic-bezier(0.4, 0, 0.2, 1)",
+        "purpose": "Radix collapsible and accordion content."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "sm",
+        "value": "640px"
+      },
+      {
+        "name": "md",
+        "value": "768px"
+      },
+      {
+        "name": "lg",
+        "value": "1024px"
+      },
+      {
+        "name": "2xl-container",
+        "value": "1400px"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Primary action for save, approve, and selected task controls.",
+      "html": "<button class=\"ds-btn-primary\">Approve change</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 36px; padding: 8px 16px; border: 0; border-radius: 6px; background: hsl(127 65% 42%); color: #fafafa; font: 500 14px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; box-shadow: 0 1px 3px rgb(0 0 0 / 0.12); transition: background 150ms ease-out, transform 150ms ease-out, box-shadow 150ms ease-out; } .ds-btn-primary:hover { background: color-mix(in srgb, hsl(127 65% 42%) 90%, black); } .ds-btn-primary:active { transform: scale(0.98); } .ds-btn-primary:focus-visible { outline: 2px solid hsl(127 65% 42%); outline-offset: 2px; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Low-emphasis action for refresh, reveal, secondary navigation, and compact tool controls.",
+      "html": "<button class=\"ds-btn-ghost\">Refresh queue</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 36px; padding: 8px 12px; border: 0; border-radius: 6px; background: transparent; color: #737373; font: 500 14px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; transition: background 150ms ease-out, color 150ms ease-out, transform 150ms ease-out; } .ds-btn-ghost:hover { background: #dceddf; color: #12541c; } .ds-btn-ghost:active { transform: scale(0.98); } .ds-btn-ghost:focus-visible { outline: 2px solid hsl(127 65% 42%); outline-offset: 2px; }"
+    },
+    {
+      "name": "Admin Card",
+      "kind": "card",
+      "refersTo": "card-default",
+      "description": "Primary admin panel for review, monitoring, queue content, and settings.",
+      "html": "<section class=\"ds-admin-card\"><div class=\"ds-admin-card-header\"><h3>Queue health</h3><p>Review items that need human attention.</p></div><div class=\"ds-admin-card-body\">24 pending reviews</div></section>",
+      "css": ".ds-admin-card { max-width: 420px; border: 1px solid #dee5df; border-radius: 12px; background: #ffffff; color: #0a0a0a; box-shadow: 0 1px 3px rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1); overflow: hidden; } .ds-admin-card-header { padding: 24px 24px 12px; } .ds-admin-card-header h3 { margin: 0; font: 600 16px/1 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; letter-spacing: -0.01em; } .ds-admin-card-header p { margin: 8px 0 0; color: #737373; font: 400 14px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; } .ds-admin-card-body { padding: 0 24px 24px; font: 400 14px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input-default",
+      "description": "Default text input for filters, settings, and editable review fields.",
+      "html": "<label class=\"ds-field\"><span>Search knowledge</span><input class=\"ds-input\" placeholder=\"Payment method, trade wizard, dispute\" /></label>",
+      "css": ".ds-field { display: grid; gap: 6px; color: #0a0a0a; font: 600 12px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; } .ds-input { height: 40px; width: 100%; border: 1px solid #dee5df; border-radius: 8px; background: rgb(255 255 255 / 0.5); color: #0a0a0a; padding: 8px 12px; font: 400 14px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; transition: background 150ms ease-out, border-color 150ms ease-out, box-shadow 150ms ease-out; } .ds-input::placeholder { color: rgb(115 115 115 / 0.8); } .ds-input:hover { background: rgb(243 246 243 / 0.3); } .ds-input:focus-visible { outline: none; border-color: hsl(127 65% 42%); box-shadow: 0 0 0 2px hsl(127 65% 42% / 0.35); }"
+    },
+    {
+      "name": "Source Badge",
+      "kind": "chip",
+      "refersTo": "badge-default",
+      "description": "Compact evidence trigger that opens source details only when verification is needed.",
+      "html": "<button class=\"ds-source-badge\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 6.5A2.5 2.5 0 0 1 6.5 4H20v14H6.5A2.5 2.5 0 0 0 4 20.5z\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"/><path d=\"M8 8h8M8 12h6\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"/></svg><span>6 sources</span></button>",
+      "css": ".ds-source-badge { display: inline-flex; align-items: center; gap: 6px; min-height: 24px; padding: 2px 10px; border: 1px solid #dee5df; border-radius: 6px; background: #f2f7f3; color: #12541c; font: 600 12px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; transition: background 150ms ease-out, border-color 150ms ease-out, transform 150ms ease-out; } .ds-source-badge svg { width: 14px; height: 14px; } .ds-source-badge:hover { background: #dceddf; border-color: color-mix(in srgb, #25b13c 35%, #dee5df); } .ds-source-badge:active { transform: scale(0.98); } .ds-source-badge:focus-visible { outline: 2px solid hsl(127 65% 42%); outline-offset: 2px; }"
+    },
+    {
+      "name": "Queue Tab",
+      "kind": "nav",
+      "refersTo": "button-primary",
+      "description": "Task filter for admin review queues. The selected tab is a filled product control, not a decorative card.",
+      "html": "<button class=\"ds-queue-tab\" aria-pressed=\"true\"><span class=\"ds-queue-tab-icon\">1</span><span class=\"ds-queue-tab-copy\"><strong>Full review</strong><small>Read the page before approving.</small></span><span class=\"ds-queue-count\">24</span></button>",
+      "css": ".ds-queue-tab { display: flex; align-items: center; gap: 10px; min-height: 48px; min-width: 220px; padding: 8px 12px; border: 0; border-radius: 6px; background: #25b13c; color: #fafafa; text-align: left; font: 500 14px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; transition: background 150ms ease-out, transform 150ms ease-out; } .ds-queue-tab:hover { background: color-mix(in srgb, #25b13c 90%, black); } .ds-queue-tab:active { transform: scale(0.98); } .ds-queue-tab:focus-visible { outline: 2px solid #25b13c; outline-offset: 2px; } .ds-queue-tab-icon { display: inline-grid; place-items: center; width: 22px; height: 22px; border-radius: 999px; background: rgb(250 250 250 / 0.18); font-size: 12px; font-weight: 700; } .ds-queue-tab-copy { display: grid; gap: 2px; min-width: 0; } .ds-queue-tab-copy strong { font-size: 14px; } .ds-queue-tab-copy small { font-size: 12px; opacity: 0.82; } .ds-queue-count { margin-left: auto; border-radius: 6px; background: #f2f7f3; color: #12541c; padding: 2px 8px; font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; }"
+    },
+    {
+      "name": "Sidebar Nav Item",
+      "kind": "nav",
+      "refersTo": "button-primary",
+      "description": "Admin navigation item with active green state and quiet inactive state.",
+      "html": "<a class=\"ds-sidebar-item ds-sidebar-item-active\" href=\"#\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 5h16v14H4z\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"/><path d=\"M8 9h8M8 13h5\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"/></svg><span>Knowledge Updates</span></a>",
+      "css": ".ds-sidebar-item { display: flex; align-items: center; gap: 10px; min-height: 36px; padding: 8px 12px; border-radius: 6px; color: #737373; text-decoration: none; font: 500 14px/1.25 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; transition: background 150ms ease-out, color 150ms ease-out; } .ds-sidebar-item svg { width: 16px; height: 16px; } .ds-sidebar-item:hover { background: #dceddf; color: #12541c; } .ds-sidebar-item-active { background: #25b13c; color: #fafafa; } .ds-sidebar-item-active:hover { background: #25b13c; color: #fafafa; } .ds-sidebar-item:focus-visible { outline: 2px solid #25b13c; outline-offset: 2px; }"
+    },
+    {
+      "name": "Diff Review Row",
+      "kind": "custom",
+      "refersTo": "card-default",
+      "description": "Inline LLM Wiki document review row that keeps change context and edit affordance in the same place.",
+      "html": "<div class=\"ds-diff-row ds-diff-row-add\"><span class=\"ds-diff-line\">42</span><p>Users can retry the trade wizard after refreshing offers and checking the selected payment method.</p></div>",
+      "css": ".ds-diff-row { display: grid; grid-template-columns: 44px minmax(0, 1fr); gap: 12px; padding: 8px 12px; border-bottom: 1px solid #dee5df; background: #ffffff; color: #0a0a0a; font: 400 14px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace; } .ds-diff-row p { margin: 0; overflow-wrap: anywhere; } .ds-diff-line { color: #737373; text-align: right; font-variant-numeric: tabular-nums; } .ds-diff-row-add { background: #f2f7f3; } .ds-diff-row-add .ds-diff-line { color: #12541c; } .ds-diff-row:hover { background: #dceddf; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Operator's Desk",
+    "overview": "The interface should feel like a quiet, well-labeled operations desk for a privacy-sensitive support system. It is not a marketing surface and it is not a playful chatbot shell. It should help a support admin understand what happened, what needs review, what source proves it, and what action is safe.",
+    "keyCharacteristics": [
+      "Review-first: generated answers, sources, diffs, and decisions stay visible in one workflow.",
+      "Calm density: compact enough for support operations, never crowded without hierarchy.",
+      "Source-backed: links, badges, and evidence states are first-class UI elements.",
+      "Familiar product UI: shadcn new-york, Radix primitives, Lucide icons, and predictable navigation.",
+      "Privacy-aware: avoid making private support evidence look permanent or public."
+    ],
+    "rules": [
+      {
+        "name": "The Green Earns Its Place Rule",
+        "body": "Green means primary action, selected state, or verified positive state. If everything is green, nothing is important.",
+        "section": "colors"
+      },
+      {
+        "name": "The Evidence Is Not Decoration Rule",
+        "body": "Source badges and evidence states use color only to clarify trust and review state, never to create ornamental variety.",
+        "section": "colors"
+      },
+      {
+        "name": "The Labels Must Explain the Job Rule",
+        "body": "Do not expose pipeline categories such as calibration or knowledge gap without explaining what the support admin should do next.",
+        "section": "typography"
+      },
+      {
+        "name": "The Native Tool Rule",
+        "body": "Product screens use the system sans stack. Do not introduce display fonts into buttons, labels, data, or admin navigation.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Until It Acts Rule",
+        "body": "Resting admin UI is quiet. Hover, focus, active, and selected states may gain emphasis because the user is interacting with them.",
+        "section": "elevation"
+      },
+      {
+        "name": "The No Glass Rule",
+        "body": "Do not use decorative blur, translucent panels, or glassmorphism in operator surfaces.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do make the support admin's next action explicit on every queue screen.",
+      "Do put source-backed evidence near the claim it verifies, with clickable links when a durable public link exists.",
+      "Do preserve the shadcn new-york component vocabulary unless there is a concrete usability reason to diverge.",
+      "Do use Bisq Support Green for active navigation, selected tabs, primary actions, and verified positive state.",
+      "Do keep operator copy concise, factual, and specific about impact.",
+      "Do explain initial bootstrap states, high raw candidate counts, and deduplication so admins do not interpret normal backlog as data corruption.",
+      "Do keep destructive actions visibly distinct, reversible when possible, and explicit about what data changes."
+    ],
+    "donts": [
+      "Don't build generic AI SaaS dashboards with decorative gradients, vague confidence badges, and unclear automation.",
+      "Don't use dark neon crypto dashboards, purple default palettes, or glassmorphism used for decoration.",
+      "Don't create FAQ sprawl where every support discussion becomes a separate public answer.",
+      "Don't hide automation decisions behind labels like Calibration or Knowledge Gap without explaining the human task.",
+      "Don't use dense admin screens that expose internal pipeline terms before explaining the operator's job.",
+      "Don't use playful copy in operator surfaces when the task involves security, trust monitoring, support escalation, or production health.",
+      "Don't duplicate evidence lists, badges, or source blocks across columns.",
+      "Don't use colored side-stripe borders, gradient text, or modal-first workflows."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,270 @@
+---
+name: "Bisq 2 Support Agent"
+description: "Operator-grade support automation for Bisq 2 with reviewable knowledge and source-backed answers."
+colors:
+  background: "#ffffff"
+  foreground: "#0a0a0a"
+  card: "#ffffff"
+  card-foreground: "#0a0a0a"
+  primary-green: "#25b13c"
+  primary-foreground: "#fafafa"
+  secondary-green-surface: "#f2f7f3"
+  secondary-green-foreground: "#12541c"
+  muted-green-surface: "#f3f6f3"
+  muted-foreground: "#737373"
+  accent-green-surface: "#dceddf"
+  accent-green-foreground: "#12541c"
+  border-green-gray: "#dee5df"
+  destructive-red: "#ef4444"
+  bisq-orange: "#f7931a"
+  dark-background: "#1a1a1a"
+  dark-card: "#242424"
+  dark-border: "#383838"
+typography:
+  display:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "1.875rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.025em"
+  headline:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "-0.01em"
+  body:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: "0.01em"
+rounded:
+  sm: "4px"
+  md: "6px"
+  lg: "8px"
+  xl: "12px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+  xl: "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.primary-green}"
+    textColor: "{colors.primary-foreground}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+    height: "36px"
+    typography: "{typography.body}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.muted-foreground}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+    height: "36px"
+    typography: "{typography.body}"
+  card-default:
+    backgroundColor: "{colors.card}"
+    textColor: "{colors.card-foreground}"
+    rounded: "{rounded.xl}"
+    padding: "24px"
+  input-default:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.lg}"
+    padding: "8px 12px"
+    height: "40px"
+    typography: "{typography.body}"
+  badge-default:
+    backgroundColor: "{colors.secondary-green-surface}"
+    textColor: "{colors.secondary-green-foreground}"
+    rounded: "{rounded.md}"
+    padding: "2px 10px"
+    typography: "{typography.label}"
+---
+
+# Design System: Bisq 2 Support Agent
+
+## 1. Overview
+
+**Creative North Star: "The Operator's Desk"**
+
+The interface should feel like a quiet, well-labeled operations desk for a privacy-sensitive support system. It is not a marketing surface and it is not a playful chatbot shell. It should help a support admin understand what happened, what needs review, what source proves it, and what action is safe.
+
+The visual system is restrained: neutral surfaces, Bisq green for primary action and active selection, orange only for deployment or progress accents, and semantic colors only when state requires them. Admin screens can be dense, but every dense region must have an obvious reading order and a clear primary job.
+
+**Key Characteristics:**
+
+- Review-first: generated answers, sources, diffs, and decisions stay visible in one workflow.
+- Calm density: compact enough for support operations, never crowded without hierarchy.
+- Source-backed: links, badges, and evidence states are first-class UI elements.
+- Familiar product UI: shadcn `new-york`, Radix primitives, Lucide icons, and predictable navigation.
+- Privacy-aware: avoid making private support evidence look permanent or public.
+
+## 2. Colors
+
+The palette is a restrained green-neutral system. Bisq green is reserved for primary actions, active navigation, source confidence, and clear positive state. It is not decorative wallpaper.
+
+### Primary
+
+- **Bisq Support Green**: The main action and active-selection color. Use for primary buttons, selected queue tabs, focus rings, active sidebar links, chart primary series, and safe positive state.
+- **Primary Foreground**: Text and icon color on green-filled controls.
+
+### Secondary
+
+- **Quiet Green Surface**: Low-emphasis surface for secondary buttons, selected badges, source capsules, and reviewed content that should read as calm rather than urgent.
+- **Deep Green Foreground**: Text on quiet green surfaces. Use when a green-tinted surface needs WCAG-safe readability.
+- **Bisq Orange**: Deployment progress and top-loader accent only. Do not use it as a general warning color unless the context is explicitly deployment or Bisq brand progress.
+
+### Neutral
+
+- **Paper Background**: Main app background for light mode.
+- **Ink Foreground**: Primary text.
+- **Card Surface**: Panels, review containers, and admin cards.
+- **Muted Green Surface**: Low-emphasis row hovers, secondary blocks, input hover surfaces, and compact preview regions.
+- **Muted Foreground**: Secondary labels, timestamps, helper copy, and metadata.
+- **Green-Gray Border**: Form borders, card borders, separators, and low-emphasis structure.
+- **Dark Graphite Background**: Dark-mode app background.
+- **Dark Graphite Card**: Dark-mode elevated surface.
+- **Dark Graphite Border**: Dark-mode borders and separators.
+
+### Semantic
+
+- **Destructive Red**: Reject, delete, failure, critical security, and hard validation errors. Do not use red for ordinary review attention.
+
+### Named Rules
+
+**The Green Earns Its Place Rule.** Green means primary action, selected state, or verified positive state. If everything is green, nothing is important.
+
+**The Evidence Is Not Decoration Rule.** Source badges and evidence states use color only to clarify trust and review state, never to create ornamental variety.
+
+## 3. Typography
+
+**Display Font:** System sans stack with platform-native rendering.
+
+**Body Font:** System sans stack with platform-native rendering.
+
+**Label/Mono Font:** Use the system monospace stack only for code, identifiers, hashes, room IDs, API paths, and durable refs.
+
+**Character:** The type system is compact, native, and operational. It favors readable UI density over expressive brand type.
+
+### Hierarchy
+
+- **Display** (700, 1.875rem, 1.2): Admin page titles and major route headings.
+- **Headline** (700, 1.5rem, 1.25): Section-level headers, dashboards, and important empty states.
+- **Title** (600, 1rem, 1): Card titles, queue item titles, panel titles, and decision labels.
+- **Body** (400, 0.875rem, 1.5): Default admin text, chat markdown, descriptions, and review guidance. Keep prose at 65 to 75 characters when it is meant to be read linearly.
+- **Label** (600, 0.75rem, 1.25): Badges, metadata, keyboard hints, compact status labels, and table-like values.
+
+### Named Rules
+
+**The Labels Must Explain the Job Rule.** Do not expose pipeline categories such as calibration or knowledge gap without explaining what the support admin should do next.
+
+**The Native Tool Rule.** Product screens use the system sans stack. Do not introduce display fonts into buttons, labels, data, or admin navigation.
+
+## 4. Elevation
+
+Depth is conveyed through tonal layering, borders, and small shadows. Cards and controls may lift slightly, but the system should never look like stacked glass panes. Most surfaces are flat at rest; state changes use background tint, border contrast, focus rings, or a short transition before using stronger elevation.
+
+### Shadow Vocabulary
+
+- **Card Resting Shadow** (`shadow` from Tailwind): Default shadcn card elevation for primary panels.
+- **Control Shadow** (`shadow-sm`): Outline and secondary buttons where the control needs separation from the background.
+- **Primary Button Shadow** (`shadow`): Filled primary actions only.
+
+### Named Rules
+
+**The Flat Until It Acts Rule.** Resting admin UI is quiet. Hover, focus, active, and selected states may gain emphasis because the user is interacting with them.
+
+**The No Glass Rule.** Do not use decorative blur, translucent panels, or glassmorphism in operator surfaces.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** Gently curved product controls (6px radius) with compact height (36px default).
+- **Primary:** Bisq Support Green fill, Primary Foreground text, medium weight, subtle shadow, 150ms transition, and active scale feedback.
+- **Hover / Focus:** Primary hover darkens by opacity. Focus uses the ring token and must remain visible on light and dark backgrounds.
+- **Secondary / Ghost:** Secondary uses Quiet Green Surface. Ghost is transparent at rest and uses Accent Green Surface on hover.
+- **Destructive:** Destructive Red is reserved for rejection, deletion, and critical failure actions.
+
+### Badges and Chips
+
+- **Style:** Rounded 6px capsules, small label typography, border by default, green fill only for selected or primary meaning.
+- **State:** Source badges must be clickable when they represent verifiable evidence. Queue count badges should stay visually secondary unless the tab is selected.
+- **Icons:** Use Lucide icons consistently at 16px in compact controls and badges.
+
+### Cards and Containers
+
+- **Corner Style:** 12px card radius for primary panels, 8px for nested compact panels.
+- **Background:** Card Surface on Paper Background. Use Muted Green Surface for low-emphasis nested content, previews, and hover rows.
+- **Shadow Strategy:** Resting card shadow is allowed on major panels only. Avoid nested card stacks.
+- **Border:** Green-Gray Border for structure. Do not use thick colored side borders.
+- **Internal Padding:** 24px for full cards, 16px for compact cards, 8px for dense internal rows.
+
+### Inputs and Text Areas
+
+- **Style:** 40px input height, 8px radius, Green-Gray Border, subtle background, muted placeholder text.
+- **Focus:** Ring token with 2px ring on primary form controls. Do not remove focus outlines.
+- **Error / Disabled:** Error uses Destructive Red with explicit helper text. Disabled uses opacity and cursor state, not color alone.
+
+### Navigation
+
+- **Admin Sidebar:** 256px desktop sidebar with card background and right border. Active items use Bisq Support Green fill and Primary Foreground text. Inactive items use Muted Foreground and hover into Accent Green Surface.
+- **Mobile Admin:** Sidebar collapses behind a menu affordance. Page content keeps the same route hierarchy and spacing rhythm.
+- **Top Loader:** Bisq Orange top-loader is a deployment and route-progress signal. Keep it thin and spinner-free.
+
+### Queues and Review Lanes
+
+- **Tabs:** Queue tabs are task filters, not decorative cards. The first tab should represent the highest manual-review burden. Labels must be action-oriented and explain what the admin does in that lane.
+- **Counts:** High backlog counts are normal during initial bootstrapping, but the UI must explain whether counts are raw candidates, deduplicated knowledge proposals, or reviewed items.
+- **Keyboard Footer:** Shortcut hints are compact operator affordances. They should not replace visible buttons for primary actions.
+
+### Source Badges
+
+- **Role:** A source badge is an invitation to verify a claim. It should show compact source count first and reveal details only when needed.
+- **Links:** Public FAQs and durable knowledge pages should open as normal links. Private or temporary support evidence must be clearly labeled as private, temporary, or unavailable.
+- **Placement:** In review workflows, sources should appear after the proposed document or answer, not before the admin understands what claim is being reviewed.
+
+### Markdown and LLM Wiki Review
+
+- **Diff & Edit:** The LLM Wiki file is the primary object of review. The admin should be able to read the full page, see proposed changes in context, and edit the document without switching mental models.
+- **Preview:** Rendered preview exists to catch formatting and readability issues, not to hide the source document.
+- **Review Notes:** Review notes are an audit trail for future reviewers. They are not model instructions unless explicitly promoted into a knowledge field.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** make the support admin's next action explicit on every queue screen.
+- **Do** put source-backed evidence near the claim it verifies, with clickable links when a durable public link exists.
+- **Do** preserve the shadcn `new-york` component vocabulary unless there is a concrete usability reason to diverge.
+- **Do** use Bisq Support Green for active navigation, selected tabs, primary actions, and verified positive state.
+- **Do** keep operator copy concise, factual, and specific about impact.
+- **Do** explain initial bootstrap states, high raw candidate counts, and deduplication so admins do not interpret normal backlog as data corruption.
+- **Do** keep destructive actions visibly distinct, reversible when possible, and explicit about what data changes.
+
+### Don't:
+
+- **Don't** build generic AI SaaS dashboards with decorative gradients, vague confidence badges, and unclear automation.
+- **Don't** use dark neon crypto dashboards, purple default palettes, or glassmorphism used for decoration.
+- **Don't** create FAQ sprawl where every support discussion becomes a separate public answer.
+- **Don't** hide automation decisions behind labels like "Calibration" or "Knowledge Gap" without explaining the human task.
+- **Don't** use dense admin screens that expose internal pipeline terms before explaining the operator's job.
+- **Don't** use playful copy in operator surfaces when the task involves security, trust monitoring, support escalation, or production health.
+- **Don't** duplicate evidence lists, badges, or source blocks across columns.
+- **Don't** use colored side-stripe borders, gradient text, or modal-first workflows.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,48 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+This product serves Bisq support operators, support admins, and project maintainers who need to keep automated Bisq 2 support reliable under real operational pressure. They use the admin UI to review escalations, inspect quality signals, tune knowledge, manage FAQs, monitor trust and security signals, and verify that Matrix and Bisq 2 support flows stay healthy.
+
+End users interact indirectly through the web chat, Matrix support rooms, and Bisq 2 support chat. They need accurate, source-backed answers, clear escalation when automation is not confident, and no exposure of private support data beyond what is required to resolve their issue.
+
+## Product Purpose
+
+Bisq 2 Support Agent is a RAG-based support system for Bisq 2. It combines wiki content, curated FAQs, LLM Wiki pages, support conversations, Bisq 2 live data, Matrix ingest, human feedback, and monitoring into one reviewable support workflow.
+
+The product exists to answer common Bisq 2 support questions safely, reduce repeated human work, and turn recurring support evidence into a lean maintained knowledge base. Success means the assistant answers correctly when evidence is strong, escalates cleanly when evidence is weak, and gives support admins a clear path to improve the underlying knowledge without creating FAQ sprawl.
+
+## Brand Personality
+
+Calm, precise, and operator-grade.
+
+The voice is concise and factual. It should feel like an expert support tool built for privacy-sensitive financial software, not a chatbot demo. UI copy should explain the next action, why it matters, and what evidence is being used. Avoid hype, vague confidence language, decorative personality, and unexplained internal labels.
+
+## Anti-references
+
+- Generic AI SaaS dashboards with decorative gradients, vague confidence badges, and unclear automation.
+- Dark neon crypto dashboards, purple default palettes, and glassmorphism used for decoration.
+- FAQ sprawl where every support discussion becomes a separate public answer.
+- Opaque automation where a human cannot see why a response was generated or why a knowledge change is proposed.
+- Dense admin screens that expose internal pipeline terms before explaining the operator's job.
+- Playful copy in operator surfaces when the task involves security, trust monitoring, support escalation, or production health.
+- Duplicate evidence lists, repeated badges, and redundant lanes that make the review order unclear.
+
+## Design Principles
+
+1. **Evidence before confidence.** The interface must show what sources support a claim before asking an admin to trust or approve it.
+2. **Reviewable automation.** AI output is never a black box. Proposed answers, knowledge diffs, confidence thresholds, escalations, and alerts must be inspectable and reversible.
+3. **One maintained knowledge source.** The long-term target is a lean LLM Wiki that absorbs recurring support learning. FAQs remain durable public answers, not the default sink for every support conversation.
+4. **Progressive disclosure by risk.** Safe, routine items can stay compact. Risky, unsupported, security-sensitive, or user-facing changes need fuller context and explicit confirmation.
+5. **Operator calm.** Admin screens should reduce cognitive load with clear queue order, action-oriented labels, stable layout, and restrained visual emphasis.
+6. **Production parity.** Local and production flows should behave predictably. Monitoring, deployment, nginx routing, Matrix rooms, and Bisq API pairing need visible health states when they affect support quality.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.2 AA for the web UI. Support keyboard navigation, visible focus states, readable contrast in light and dark themes, reduced-motion-safe interactions, and labels that do not rely on color alone.
+
+Operator screens should use plain language for non-native English readers. Dates, source references, alert states, confidence states, and destructive actions must be explicit. Source links must be reachable, durable when possible, and clearly marked when they point to private or temporary evidence.

--- a/web/src/app/admin/knowledge-updates/page.tsx
+++ b/web/src/app/admin/knowledge-updates/page.tsx
@@ -20,6 +20,7 @@ import {
   Sparkles,
   ThumbsDown,
   ThumbsUp,
+  X,
   XCircle,
   type LucideIcon,
 } from "lucide-react";
@@ -88,22 +89,60 @@ interface DiffRow {
 }
 
 const QUEUE_LABELS: Record<RoutingCategory, string> = {
-  FULL_REVIEW: "Knowledge Gap",
-  SPOT_CHECK: "Minor Gap",
-  AUTO_APPROVE: "Calibration",
+  FULL_REVIEW: "1. Full review",
+  SPOT_CHECK: "2. Spot check",
+  AUTO_APPROVE: "3. Ready queue",
 };
 
 const QUEUE_TABS = [
-  { key: "FULL_REVIEW" as const, label: QUEUE_LABELS.FULL_REVIEW, icon: BookOpenCheck },
-  { key: "SPOT_CHECK" as const, label: QUEUE_LABELS.SPOT_CHECK, icon: ShieldCheck },
-  { key: "AUTO_APPROVE" as const, label: QUEUE_LABELS.AUTO_APPROVE, icon: GraduationCap },
+  {
+    key: "FULL_REVIEW" as const,
+    label: QUEUE_LABELS.FULL_REVIEW,
+    description: "Start here: highest review risk",
+    countLabel: "pending candidates",
+    icon: BookOpenCheck,
+  },
+  {
+    key: "SPOT_CHECK" as const,
+    label: QUEUE_LABELS.SPOT_CHECK,
+    description: "Lower-risk edits to verify",
+    countLabel: "pending candidates",
+    icon: ShieldCheck,
+  },
+  {
+    key: "AUTO_APPROVE" as const,
+    label: QUEUE_LABELS.AUTO_APPROVE,
+    description: "High-confidence backlog",
+    countLabel: "pending candidates",
+    icon: GraduationCap,
+  },
 ];
+
+const QUEUE_GUIDANCE: Record<RoutingCategory, { title: string; body: string; nextAction: string }> = {
+  FULL_REVIEW: {
+    title: "Start with full review",
+    body: "These candidates need the most human judgment. Read the proposed LLM Wiki page, edit weak wording, and check sources when a claim looks risky or unsupported.",
+    nextAction: "Approve only when the final page is reusable support knowledge.",
+  },
+  SPOT_CHECK: {
+    title: "Spot-check lower-risk edits",
+    body: "These candidates look closer to existing knowledge. Read the changed page first, then open sources only for claims that feel surprising, broad, or user-facing.",
+    nextAction: "Use this lane after the full-review queue is under control.",
+  },
+  AUTO_APPROVE: {
+    title: "Use the ready queue last",
+    body: "These candidates were routed as high confidence, but during initial bootstrapping they still deserve quick sampling so the generated LLM Wiki stays clean.",
+    nextAction: "Do not treat this as the first lane for manual cleanup.",
+  },
+};
 
 const SHORTCUT_HINTS = [
   { keyCombo: "S", label: "Save document" },
   { keyCombo: "A", label: "Approve" },
   { keyCombo: "R", label: "Reject" },
 ];
+
+const REVIEW_GUIDE_STORAGE_KEY = "bisq-support:knowledge-updates:review-guide-dismissed";
 
 const DOCUMENT_REVIEW_MODES: Array<{
   key: DocumentReviewMode;
@@ -294,6 +333,140 @@ function ContextBadge({
   );
 }
 
+function formatCandidateCount(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "candidate" : "candidates"}`;
+}
+
+function KnowledgeUpdateReviewGuide({
+  counts,
+  activeQueue,
+  isDismissed,
+  onDismiss,
+  onShow,
+}: {
+  counts: QueueCounts;
+  activeQueue: RoutingCategory;
+  isDismissed: boolean | null;
+  onDismiss: () => void;
+  onShow: () => void;
+}) {
+  const total = counts.FULL_REVIEW + counts.SPOT_CHECK + counts.AUTO_APPROVE;
+  const guidance = QUEUE_GUIDANCE[activeQueue];
+  const activeCount = counts[activeQueue] ?? 0;
+
+  if (isDismissed === null) return null;
+
+  if (isDismissed) {
+    return (
+      <div className="flex justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onShow}
+          className="gap-2 text-muted-foreground hover:text-foreground"
+        >
+          <BookOpenCheck className="h-4 w-4" aria-hidden="true" />
+          Show review guide
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Card className="relative border-primary/20 bg-secondary/40 shadow-sm">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onDismiss}
+        className="absolute right-3 top-3 z-10 h-8 w-8 text-muted-foreground hover:bg-background/70 hover:text-foreground"
+        aria-label="Hide review guide"
+        title="Hide review guide"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </Button>
+      <CardContent className="p-4 pr-14 md:p-5 md:pr-16">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]">
+          <div className="space-y-3">
+            <div className="flex min-w-0 items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-primary/10 p-2 text-primary">
+                <BookOpenCheck className="h-4 w-4" aria-hidden="true" />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-base font-semibold">Your job: approve one reusable LLM Wiki page at a time</h2>
+                <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+                  The page turns repeated support evidence into internal knowledge the bot can retrieve later.
+                  It is not asking you to create hundreds of FAQs. Read the proposed page first, edit it if
+                  needed, then spot-check sources only when a claim looks wrong, unsupported, or risky.
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-3">
+              {[
+                ["1", "Read the wiki page", "Check whether the reusable answer is precise and durable."],
+                ["2", "Open sources only if needed", "Use support evidence to verify suspicious or high-impact claims."],
+                ["3", "Approve, skip, or reject", "Approval updates internal LLM Wiki knowledge, not a public FAQ."],
+              ].map(([step, title, body]) => (
+                <div key={step} className="rounded-lg border border-border/70 bg-background/70 p-3">
+                  <div className="flex items-center gap-2">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-full bg-foreground text-[11px] font-semibold text-background">
+                      {step}
+                    </span>
+                    <p className="text-sm font-medium">{title}</p>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">{body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-border/70 bg-background/80 p-4">
+            <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">{guidance.title}</p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">{guidance.body}</p>
+                  <p className="mt-1 text-xs font-medium text-foreground">{guidance.nextAction}</p>
+                </div>
+                <Badge variant="secondary" className="shrink-0 justify-center tabular-nums">
+                  {formatCandidateCount(activeCount)}
+                </Badge>
+              </div>
+            </div>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium">About the backlog</p>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  The lane numbers are pending support candidates, not final pages. A large initial count is
+                  expected while bootstrapping; approving one good LLM Wiki page can absorb many similar
+                  future questions.
+                </p>
+              </div>
+              <Badge variant="outline" className="shrink-0 tabular-nums">
+                {total.toLocaleString()}
+              </Badge>
+            </div>
+            <div className="mt-3 grid gap-2 text-xs">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Full review</span>
+                <span className="font-medium tabular-nums">{formatCandidateCount(counts.FULL_REVIEW)}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Spot check</span>
+                <span className="font-medium tabular-nums">{formatCandidateCount(counts.SPOT_CHECK)}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Ready queue</span>
+                <span className="font-medium tabular-nums">{formatCandidateCount(counts.AUTO_APPROVE)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function CompactKnowledgeSources({
   sources,
 }: {
@@ -333,7 +506,7 @@ function DocumentDiffViewer({
     <div className="overflow-hidden rounded-xl border border-border/70 bg-background">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/70 bg-muted/20 px-3 py-2">
         <div>
-          <p className="text-sm font-medium">Full document diff</p>
+          <p className="text-sm font-medium">Full wiki file: diff & edit</p>
           <p className="text-xs text-muted-foreground">
             Click a proposed line to edit it in place while keeping the diff context visible.
           </p>
@@ -531,6 +704,7 @@ export default function KnowledgeUpdatesPage() {
   const [showSupportingEdits, setShowSupportingEdits] = useState(false);
   const [answerRating, setAnswerRating] = useState<AnswerRating | null>(null);
   const [ratingLoading, setRatingLoading] = useState<AnswerRating | null>(null);
+  const [isReviewGuideDismissed, setIsReviewGuideDismissed] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const isOperationDirty = useMemo(
@@ -630,11 +804,39 @@ export default function KnowledgeUpdatesPage() {
   }, [loadData]);
 
   useEffect(() => {
+    try {
+      setIsReviewGuideDismissed(
+        window.localStorage.getItem(REVIEW_GUIDE_STORAGE_KEY) === "true",
+      );
+    } catch {
+      setIsReviewGuideDismissed(false);
+    }
+  }, []);
+
+  useEffect(() => {
     setAnswerRating(null);
     setRatingLoading(null);
     setShowSupportingEdits(false);
     setEditingDocumentLine(null);
   }, [data?.candidate.id, data?.candidate.generated_answer]);
+
+  const handleDismissReviewGuide = useCallback(() => {
+    setIsReviewGuideDismissed(true);
+    try {
+      window.localStorage.setItem(REVIEW_GUIDE_STORAGE_KEY, "true");
+    } catch {
+      // Local storage can be unavailable in hardened browser contexts.
+    }
+  }, []);
+
+  const handleShowReviewGuide = useCallback(() => {
+    setIsReviewGuideDismissed(false);
+    try {
+      window.localStorage.removeItem(REVIEW_GUIDE_STORAGE_KEY);
+    } catch {
+      // Local storage can be unavailable in hardened browser contexts.
+    }
+  }, []);
 
   const persistOperations = async (): Promise<KnowledgeProposal | null> => {
     if (!data || !isOperationDirty) return data?.proposal ?? null;
@@ -861,7 +1063,7 @@ export default function KnowledgeUpdatesPage() {
     <AdminQueueShell showVectorStoreBanner shortcutHints={SHORTCUT_HINTS}>
       <QueuePageHeader
         title="Knowledge Updates"
-        description="Verify support evidence, refine the proposed LLM Wiki change, then approve or reject what should become retrievable knowledge."
+        description="Review proposed LLM Wiki pages created from real support discussions. Start with Full review, then use Spot check and Ready queue as lower-risk follow-up lanes."
         lastUpdatedLabel={lastUpdatedAt ? `Updated ${formatDate(lastUpdatedAt.toISOString())}` : null}
         isRefreshing={isRefreshing}
         onRefresh={() => void loadData({ silent: true })}
@@ -887,6 +1089,14 @@ export default function KnowledgeUpdatesPage() {
         tabs={tabs}
         activeTab={activeQueue}
         onTabChange={setActiveQueue}
+      />
+
+      <KnowledgeUpdateReviewGuide
+        counts={queueCounts}
+        activeQueue={activeQueue}
+        isDismissed={isReviewGuideDismissed}
+        onDismiss={handleDismissReviewGuide}
+        onShow={handleShowReviewGuide}
       />
 
       {error && (
@@ -916,135 +1126,7 @@ export default function KnowledgeUpdatesPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.25fr)_minmax(280px,0.8fr)]">
-          <Card className="min-w-0 border-border/70 bg-card/80">
-            <CardHeader className="pb-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <ContextBadge
-                  label="Channel"
-                  value={data.candidate.source === "bisq2" ? "Bisq 2" : "Matrix"}
-                  icon={MessageSquare}
-                />
-                {data.candidate.category && (
-                  <ContextBadge label="Topic" value={data.candidate.category} icon={FileText} />
-                )}
-                <ContextBadge label="Protocol" value={protocolLabel(data.candidate.protocol)} icon={ShieldCheck} />
-              </div>
-              <CardTitle className="pt-2 text-base">Support evidence</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Verify what the user asked, what staff answered, and whether the AI draft could have been sent as-is.
-              </p>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <section className="space-y-2">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">User question</p>
-                <div className="rounded-lg border border-border/70 bg-muted/25 p-3 text-sm leading-6">
-                  {data.candidate.edited_question_text || data.candidate.question_text}
-                </div>
-              </section>
-              <section className="space-y-2">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Staff answer</p>
-                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 text-sm leading-6 whitespace-pre-wrap">
-                  {data.candidate.edited_staff_answer || data.candidate.staff_answer}
-                </div>
-              </section>
-              {cleanedGeneratedAnswer && (
-                <section className="space-y-3">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      <Bot className="h-3.5 w-3.5" aria-hidden="true" />
-                      AI draft answer
-                    </p>
-                    {generationConfidenceLabel && (
-                      <Badge variant="outline" className="h-6 text-[11px]">
-                        Confidence {generationConfidenceLabel}
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-sm leading-6">
-                    <MarkdownContent content={cleanedGeneratedAnswer} />
-                    {data.candidate.generated_answer_sources && data.candidate.generated_answer_sources.length > 0 && (
-                      <div className="mt-3 border-t border-border/50 pt-3">
-                        <SourceBadges sources={data.candidate.generated_answer_sources} />
-                      </div>
-                    )}
-                  </div>
-                  <div className="rounded-lg border border-dashed border-border bg-muted/15 p-3">
-                    <div className="space-y-3">
-                      <div>
-                        <p className="text-sm font-medium leading-5">Was this AI draft good enough to send?</p>
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                          Records a training signal only. It does not approve the LLM Wiki change.
-                        </p>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2">
-                        <Button
-                          variant={answerRating === "needs_improvement" ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => void handleRateGeneratedAnswer("needs_improvement")}
-                          disabled={ratingLoading !== null}
-                          className={cn(
-                            "w-full justify-center gap-1.5 px-2 text-xs",
-                            answerRating === "needs_improvement"
-                              ? "bg-amber-600 text-white hover:bg-amber-700"
-                              : "text-amber-700 hover:bg-amber-50 hover:text-amber-800",
-                          )}
-                        >
-                          {ratingLoading === "needs_improvement" ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <ThumbsDown className="h-3.5 w-3.5" />
-                          )}
-                          Needs Work
-                        </Button>
-                        <Button
-                          variant={answerRating === "good" ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => void handleRateGeneratedAnswer("good")}
-                          disabled={ratingLoading !== null}
-                          className={cn(
-                            "w-full justify-center gap-1.5 px-2 text-xs",
-                            answerRating === "good"
-                              ? "bg-emerald-600 text-white hover:bg-emerald-700"
-                              : "text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800",
-                          )}
-                        >
-                          {ratingLoading === "good" ? (
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <ThumbsUp className="h-3.5 w-3.5" />
-                          )}
-                          Good
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </section>
-              )}
-              {conversation.length > 0 && (
-                <Collapsible open={showConversation} onOpenChange={setShowConversation}>
-                  <CollapsibleTrigger asChild>
-                    <Button variant="ghost" className="w-full justify-between px-2">
-                      Conversation context
-                      <ChevronDown className={cn("h-4 w-4 transition-transform", showConversation && "rotate-180")} />
-                    </Button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="space-y-2">
-                    {conversation.map((message, index) => (
-                      <div key={`${message.timestamp}-${index}`} className="rounded-lg border border-border/60 bg-muted/20 p-3">
-                        <div className="mb-1 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-                          <span>{message.sender || "participant"}</span>
-                          <span>{message.timestamp ? formatDate(message.timestamp) : ""}</span>
-                        </div>
-                        <p className="whitespace-pre-wrap text-sm leading-6">{message.content}</p>
-                      </div>
-                    ))}
-                  </CollapsibleContent>
-                </Collapsible>
-              )}
-            </CardContent>
-          </Card>
-
+        <div className="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,0.95fr)_minmax(280px,0.75fr)]">
           <Card className="min-w-0 border-border/70 bg-card/90">
             <CardHeader className="pb-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1056,8 +1138,8 @@ export default function KnowledgeUpdatesPage() {
                       : "Creating a new internal LLM Wiki page"}
                   </p>
                   <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-                    Review the complete markdown file first. Inline edits keep changed paragraphs in context;
-                    source links stay nearby for spot checks.
+                    This is the main object you approve. Read the complete page first, then edit unclear
+                    wording directly in the diff. Open sources only when a claim needs proof.
                   </p>
                 </div>
                 {isDirty && (
@@ -1084,12 +1166,12 @@ export default function KnowledgeUpdatesPage() {
                   <div className="flex items-center gap-2 text-sm font-medium">
                     <ArrowRight className="hidden h-4 w-4 text-muted-foreground sm:block" aria-hidden="true" />
                     <CheckCircle2 className="h-4 w-4 text-emerald-500" aria-hidden="true" />
-                    Decide
+                    Approve or reject
                   </div>
                 </div>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Start with the final LLM Wiki file. Open sources only when a claim looks unsupported,
-                  risky, or oddly worded, then approve only if the final text should become reusable support knowledge.
+                  Approval updates the internal LLM Wiki. It does not publish a public FAQ and it does not
+                  immediately change autoresponse confidence thresholds.
                 </p>
               </div>
 
@@ -1150,15 +1232,16 @@ export default function KnowledgeUpdatesPage() {
                   <Button variant="ghost" className="w-full justify-between px-2">
                     <span className="inline-flex items-center gap-2">
                       <PencilLine className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                      Generated structured suggestions
+                      Advanced: generated fields
                     </span>
                     <ChevronDown className={cn("h-4 w-4 transition-transform", showSupportingEdits && "rotate-180")} />
                   </Button>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-3 pt-2">
                   <p className="rounded-lg border border-border/70 bg-muted/15 p-3 text-xs leading-5 text-muted-foreground">
-                    These fields are the generator output behind the document diff. Edit them for normal
-                    section-level fixes; most reviews should happen directly in Diff & edit.
+                    These fields are the generator output behind the document. Most reviews should happen
+                    directly in Diff & edit. Open this section only when you need to understand or repair
+                    a specific generated field.
                   </p>
                   <section className="space-y-3">
                     <div>
@@ -1185,12 +1268,142 @@ export default function KnowledgeUpdatesPage() {
             </CardContent>
           </Card>
 
-          <aside className="min-w-0 space-y-4 xl:sticky xl:top-6 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto xl:pr-1">
+          <Card className="min-w-0 border-border/70 bg-card/80">
+            <CardHeader className="pb-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <ContextBadge
+                  label="Channel"
+                  value={data.candidate.source === "bisq2" ? "Bisq 2" : "Matrix"}
+                  icon={MessageSquare}
+                />
+                {data.candidate.category && (
+                  <ContextBadge label="Topic" value={data.candidate.category} icon={FileText} />
+                )}
+                <ContextBadge label="Protocol" value={protocolLabel(data.candidate.protocol)} icon={ShieldCheck} />
+              </div>
+              <CardTitle className="pt-2 text-base">Evidence from support chat</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Use this after reading the wiki page. Verify the original question, the human staff answer,
+                and whether the bot draft would have been good enough.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <section className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">User question</p>
+                <div className="rounded-lg border border-border/70 bg-muted/25 p-3 text-sm leading-6">
+                  {data.candidate.edited_question_text || data.candidate.question_text}
+                </div>
+              </section>
+              <section className="space-y-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Human staff answer</p>
+                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 text-sm leading-6 whitespace-pre-wrap">
+                  {data.candidate.edited_staff_answer || data.candidate.staff_answer}
+                </div>
+              </section>
+              {cleanedGeneratedAnswer && (
+                <section className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="inline-flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      <Bot className="h-3.5 w-3.5" aria-hidden="true" />
+                      Bot draft at ingest
+                    </p>
+                    {generationConfidenceLabel && (
+                      <Badge variant="outline" className="h-6 text-[11px]">
+                        Confidence {generationConfidenceLabel}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-sm leading-6">
+                    <MarkdownContent content={cleanedGeneratedAnswer} />
+                    {data.candidate.generated_answer_sources && data.candidate.generated_answer_sources.length > 0 && (
+                      <div className="mt-3 border-t border-border/50 pt-3">
+                        <SourceBadges sources={data.candidate.generated_answer_sources} />
+                      </div>
+                    )}
+                  </div>
+                  <div className="rounded-lg border border-dashed border-border bg-muted/15 p-3">
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-sm font-medium leading-5">Could the bot have sent this answer?</p>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                          Records an answer-quality signal only. It does not approve the LLM Wiki change or change channel thresholds.
+                        </p>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <Button
+                          variant={answerRating === "needs_improvement" ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => void handleRateGeneratedAnswer("needs_improvement")}
+                          disabled={ratingLoading !== null}
+                          className={cn(
+                            "w-full justify-center gap-1.5 px-2 text-xs",
+                            answerRating === "needs_improvement"
+                              ? "bg-amber-600 text-white hover:bg-amber-700"
+                              : "text-amber-700 hover:bg-amber-50 hover:text-amber-800",
+                          )}
+                        >
+                          {ratingLoading === "needs_improvement" ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <ThumbsDown className="h-3.5 w-3.5" />
+                          )}
+                          Needs work
+                        </Button>
+                        <Button
+                          variant={answerRating === "good" ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => void handleRateGeneratedAnswer("good")}
+                          disabled={ratingLoading !== null}
+                          className={cn(
+                            "w-full justify-center gap-1.5 px-2 text-xs",
+                            answerRating === "good"
+                              ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                              : "text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800",
+                          )}
+                        >
+                          {ratingLoading === "good" ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <ThumbsUp className="h-3.5 w-3.5" />
+                          )}
+                          Good enough
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+              )}
+              {conversation.length > 0 && (
+                <Collapsible open={showConversation} onOpenChange={setShowConversation}>
+                  <CollapsibleTrigger asChild>
+                    <Button variant="ghost" className="w-full justify-between px-2">
+                      Full support thread
+                      <ChevronDown className={cn("h-4 w-4 transition-transform", showConversation && "rotate-180")} />
+                    </Button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="space-y-2">
+                    {conversation.map((message, index) => (
+                      <div key={`${message.timestamp}-${index}`} className="rounded-lg border border-border/60 bg-muted/20 p-3">
+                        <div className="mb-1 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                          <span>{message.sender || "participant"}</span>
+                          <span>{message.timestamp ? formatDate(message.timestamp) : ""}</span>
+                        </div>
+                        <p className="whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                      </div>
+                    ))}
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
+            </CardContent>
+          </Card>
+
+          <aside className="order-3 min-w-0 space-y-4 xl:sticky xl:top-6 xl:max-h-[calc(100vh-3rem)] xl:overflow-y-auto xl:pr-1">
             <Card className="border-border/70 bg-card/80">
               <CardHeader className="pb-3">
                 <CardTitle className="text-base">Decision</CardTitle>
                 <p className="text-sm text-muted-foreground">
-                  Apply the reviewed change, defer it, or route it to a public FAQ.
+                  Approve only when the final wiki page should become retrievable support knowledge.
+                  Use FAQ only for a durable public one-question answer.
                 </p>
               </CardHeader>
               <CardContent className="space-y-3 p-4">
@@ -1219,7 +1432,7 @@ export default function KnowledgeUpdatesPage() {
                     <Button variant="ghost" className="w-full justify-between text-muted-foreground">
                       <span className="inline-flex items-center gap-2">
                         <HelpCircle className="h-4 w-4" />
-                        FAQ escape hatch
+                        Optional public FAQ
                       </span>
                       <ChevronDown className={cn("h-4 w-4 transition-transform", showFaqFallback && "rotate-180")} />
                     </Button>

--- a/web/src/app/admin/knowledge-updates/page.tsx
+++ b/web/src/app/admin/knowledge-updates/page.tsx
@@ -379,7 +379,7 @@ function KnowledgeUpdateReviewGuide({
         variant="ghost"
         size="icon"
         onClick={onDismiss}
-        className="absolute right-3 top-3 z-10 h-8 w-8 text-muted-foreground hover:bg-background/70 hover:text-foreground"
+        className="absolute right-[13px] top-[13px] z-10 h-8 w-8 text-muted-foreground hover:bg-background/70 hover:text-foreground"
         aria-label="Hide review guide"
         title="Hide review guide"
       >

--- a/web/src/components/admin/queue/QueueTabs.tsx
+++ b/web/src/components/admin/queue/QueueTabs.tsx
@@ -8,7 +8,9 @@ import { LucideIcon } from "lucide-react";
 interface QueueTabItem<TTabKey extends string> {
   key: TTabKey;
   label: string;
+  description?: string;
   count: number;
+  countLabel?: string;
   icon: LucideIcon;
 }
 
@@ -40,15 +42,31 @@ export function QueueTabs<TTabKey extends string>({
                 variant={isSelected ? "default" : "ghost"}
                 size="sm"
                 className={cn(
-                  "h-auto min-h-11 min-w-52 flex-1 justify-start gap-2 px-3 py-2 text-left sm:min-w-0",
+                  "h-auto min-h-11 min-w-52 flex-1 items-start justify-start gap-2 px-3 py-2 text-left sm:min-w-0",
                   !isSelected && "text-muted-foreground hover:text-foreground",
                 )}
                 aria-pressed={isSelected}
                 onClick={() => onTabChange(item.key)}
               >
-                <Icon className="h-4 w-4 shrink-0" />
-                <span className="truncate">{item.label}</span>
-                <Badge variant={isSelected ? "secondary" : "outline"} className="ml-auto tabular-nums">
+                <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate">{item.label}</span>
+                  {item.description && (
+                    <span
+                      className={cn(
+                        "mt-0.5 block truncate text-xs font-normal leading-4",
+                        isSelected ? "text-primary-foreground/80" : "text-muted-foreground",
+                      )}
+                    >
+                      {item.description}
+                    </span>
+                  )}
+                </span>
+                <Badge
+                  variant={isSelected ? "secondary" : "outline"}
+                  className="ml-auto shrink-0 tabular-nums"
+                  title={`${item.count} ${item.countLabel ?? "items"}`}
+                >
                   {item.count}
                 </Badge>
               </Button>


### PR DESCRIPTION
## Summary

- Adds repository design context files (`PRODUCT.md`, `DESIGN.md`, `.impeccable/design.json`) so future UI work has explicit product and design-system guidance.
- Reworks the Knowledge Updates admin flow to explain the support admin's job in plain language and establish the lane order: Full review, Spot check, Ready queue.
- Adds a dismissible review guide that persists locally and can be reopened, with the close control anchored to the top-right corner on desktop.
- Improves queue tabs with descriptions and count labels, and clarifies that approving an LLM Wiki change does not publish a public FAQ or change autoresponse thresholds.
- Moves the workflow emphasis to reading the LLM Wiki file first, using evidence only for spot checks, then approving/rejecting.

## Why

Support admins reported confusion about the three lanes, the backlog count, and what their primary job was on the Knowledge Updates page. This PR reduces initial cognitive load while keeping a first-run guide available for orientation.

## Validation

- `git diff --check`
- `cd web && npm run lint`
- `cd web && npm run test -- --runInBand`
- Local browser check of `/admin/knowledge-updates` with the review guide visible
- Geometry check: close button is 13px from the guide card's top and right edges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible review guide card to the admin Knowledge Updates page, providing contextual guidance for queue management.
  * Enhanced queue tabs with descriptive labels and improved count display formatting.

* **Documentation**
  * Established comprehensive design system documentation with standardized colors, typography, and component patterns.
  * Added product guidance documentation defining system principles, accessibility requirements, and operator UX standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->