### PR TITLE
Add realtime escalation response events

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -289,8 +289,12 @@ async def lifespan(app: FastAPI):
 
     # Initialize EscalationService singleton for admin routes, polling, and hooks.
     app.state.escalation_service = None
+    app.state.escalation_event_broker = None
     app.state.escalation_init_failed = False
     try:
+        from app.services.escalation.escalation_event_broker import (
+            EscalationEventBroker,
+        )
         from app.services.escalation.escalation_repository import EscalationRepository
         from app.services.escalation.escalation_service import EscalationService
         from app.services.escalation.feedback_orchestrator import FeedbackOrchestrator
@@ -304,6 +308,8 @@ async def lifespan(app: FastAPI):
             settings=settings,
         )
         app.state.feedback_orchestrator = feedback_orchestrator
+        event_broker = EscalationEventBroker()
+        app.state.escalation_event_broker = event_broker
 
         escalation_service = EscalationService(
             repository=esc_repo,
@@ -314,11 +320,13 @@ async def lifespan(app: FastAPI):
             feedback_orchestrator=feedback_orchestrator,
             embeddings=embeddings_model,
             rag_service=rag_service,
+            event_broker=event_broker,
         )
         app.state.escalation_service = escalation_service
         logger.info("EscalationService initialized (singleton)")
     except Exception:
         app.state.escalation_service = None
+        app.state.escalation_event_broker = None
         app.state.feedback_orchestrator = None
         app.state.escalation_init_failed = True
         logger.critical("EscalationService init failed", exc_info=True)

--- a/api/app/routes/escalation_polling.py
+++ b/api/app/routes/escalation_polling.py
@@ -2,8 +2,10 @@
 User-facing polling endpoint for escalation responses.
 """
 
+import asyncio
+import json
 import logging
-import re
+from typing import AsyncIterator
 
 from app.channels.escalation_localization import normalize_language_code
 from app.channels.plugins.web.identity import derive_web_user_context
@@ -19,6 +21,7 @@ from app.services.escalation.rating_token import (
     verify_rating_token,
 )
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+from fastapi.responses import StreamingResponse
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -28,7 +31,7 @@ router = APIRouter()
 
 # Message ID pattern: optional channel prefix + UUID v4
 # Examples: "160541ae-..." (plain UUID) or "web_160541ae-..." (channel-prefixed)
-MESSAGE_ID_PATTERN = re.compile(
+MESSAGE_ID_PATH_PATTERN = (
     r"^(?:[a-z]+_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 )
 
@@ -121,13 +124,119 @@ async def _localize_staff_answer(
     return answer
 
 
+async def _get_escalation_or_404(service, message_id: str):
+    escalation = await service.repository.get_by_message_id(message_id)
+
+    if not escalation:
+        logger.debug(f"Message ID not found: {message_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"status": "not_found"},
+        )
+    return escalation
+
+
+async def _build_user_poll_response(
+    *,
+    request: Request,
+    escalation,
+    message_id: str,
+    settings,
+) -> UserPollResponse:
+    signing_key = _get_rating_signing_key(settings)
+    rater_id = _derive_rater_id(request)
+    localized_staff_answer = await _localize_staff_answer(
+        request=request,
+        escalation=escalation,
+    )
+
+    if escalation.status in (
+        EscalationStatus.PENDING,
+        EscalationStatus.IN_REVIEW,
+    ):
+        return UserPollResponse(
+            status="pending",
+            staff_answer=None,
+            responded_at=None,
+            resolution=None,
+            closed_at=None,
+            user_language=escalation.user_language,
+        )
+
+    if escalation.status == EscalationStatus.RESPONDED:
+        rate_token = _build_rate_token_for_escalation(
+            escalation=escalation,
+            message_id=message_id,
+            rater_id=rater_id,
+            signing_key=signing_key,
+            settings=settings,
+        )
+        return UserPollResponse(
+            status="resolved",
+            staff_answer=localized_staff_answer,
+            responded_at=escalation.responded_at,
+            resolution="responded",
+            closed_at=None,
+            staff_answer_rating=escalation.staff_answer_rating,
+            rate_token=rate_token,
+            user_language=escalation.user_language,
+        )
+
+    if escalation.status == EscalationStatus.CLOSED:
+        rate_token = _build_rate_token_for_escalation(
+            escalation=escalation,
+            message_id=message_id,
+            rater_id=rater_id,
+            signing_key=signing_key,
+            settings=settings,
+        )
+        return UserPollResponse(
+            status="resolved",
+            staff_answer=localized_staff_answer,
+            responded_at=escalation.responded_at,
+            resolution=_derive_user_resolution(escalation),
+            closed_at=escalation.closed_at,
+            staff_answer_rating=escalation.staff_answer_rating,
+            rate_token=rate_token,
+            user_language=escalation.user_language,
+        )
+
+    return UserPollResponse(
+        status="pending",
+        staff_answer=None,
+        responded_at=None,
+        resolution=None,
+        closed_at=None,
+        user_language=escalation.user_language,
+    )
+
+
+def _is_terminal_user_response(response: UserPollResponse) -> bool:
+    return response.status == "resolved" and (
+        bool(response.staff_answer) or response.resolution == "closed"
+    )
+
+
+def _format_sse_event(event: str, payload: UserPollResponse) -> str:
+    data = payload.model_dump(mode="json")
+    encoded = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return f"event: {event}\ndata: {encoded}\n\n"
+
+
+def _get_event_broker(request: Request, service):
+    broker = getattr(service, "event_broker", None)
+    if broker is not None:
+        return broker
+    return getattr(request.app.state, "escalation_event_broker", None)
+
+
 @router.get("/escalations/{message_id}/response", response_model=UserPollResponse)
 async def poll_escalation_response(
     request: Request,
     message_id: str = Path(
         ...,
         description="Message ID from the original question (UUID with optional channel prefix)",
-        pattern=r"^(?:[a-z]+_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        pattern=MESSAGE_ID_PATH_PATTERN,
     ),
     service=Depends(get_escalation_service),
     settings=Depends(get_settings),
@@ -149,88 +258,13 @@ async def poll_escalation_response(
     logger.debug(f"User polling for escalation response: {message_id}")
 
     try:
-        signing_key = _get_rating_signing_key(settings)
-        rater_id = _derive_rater_id(request)
-
-        # Get escalation by message_id
-        escalation = await service.repository.get_by_message_id(message_id)
-
-        if not escalation:
-            logger.debug(f"Message ID not found: {message_id}")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail={"status": "not_found"},
-            )
-        localized_staff_answer = await _localize_staff_answer(
+        escalation = await _get_escalation_or_404(service, message_id)
+        return await _build_user_poll_response(
             request=request,
             escalation=escalation,
+            message_id=message_id,
+            settings=settings,
         )
-
-        # Check status and return appropriate response
-        if escalation.status == EscalationStatus.PENDING:
-            return UserPollResponse(
-                status="pending",
-                staff_answer=None,
-                responded_at=None,
-                resolution=None,
-                closed_at=None,
-                user_language=escalation.user_language,
-            )
-        elif escalation.status == EscalationStatus.IN_REVIEW:
-            return UserPollResponse(
-                status="pending",
-                staff_answer=None,
-                responded_at=None,
-                resolution=None,
-                closed_at=None,
-                user_language=escalation.user_language,
-            )
-        elif escalation.status == EscalationStatus.RESPONDED:
-            rate_token = _build_rate_token_for_escalation(
-                escalation=escalation,
-                message_id=message_id,
-                rater_id=rater_id,
-                signing_key=signing_key,
-                settings=settings,
-            )
-            return UserPollResponse(
-                status="resolved",
-                staff_answer=localized_staff_answer,
-                responded_at=escalation.responded_at,
-                resolution="responded",
-                closed_at=None,
-                staff_answer_rating=escalation.staff_answer_rating,
-                rate_token=rate_token,
-                user_language=escalation.user_language,
-            )
-        elif escalation.status == EscalationStatus.CLOSED:
-            rate_token = _build_rate_token_for_escalation(
-                escalation=escalation,
-                message_id=message_id,
-                rater_id=rater_id,
-                signing_key=signing_key,
-                settings=settings,
-            )
-            return UserPollResponse(
-                status="resolved",
-                staff_answer=localized_staff_answer,
-                responded_at=escalation.responded_at,
-                resolution=_derive_user_resolution(escalation),
-                closed_at=escalation.closed_at,
-                staff_answer_rating=escalation.staff_answer_rating,
-                rate_token=rate_token,
-                user_language=escalation.user_language,
-            )
-        else:
-            # Unknown status, return pending to be safe
-            return UserPollResponse(
-                status="pending",
-                staff_answer=None,
-                responded_at=None,
-                resolution=None,
-                closed_at=None,
-                user_language=escalation.user_language,
-            )
 
     except HTTPException:
         # Re-raise HTTP exceptions without wrapping
@@ -246,6 +280,94 @@ async def poll_escalation_response(
         ) from e
 
 
+@router.get("/escalations/{message_id}/events")
+async def stream_escalation_events(
+    request: Request,
+    message_id: str = Path(
+        ...,
+        description="Message ID from the original question (UUID with optional channel prefix)",
+        pattern=MESSAGE_ID_PATH_PATTERN,
+    ),
+    service=Depends(get_escalation_service),
+    settings=Depends(get_settings),
+) -> StreamingResponse:
+    """Stream escalation response updates via Server-Sent Events."""
+    logger.debug(f"User streaming escalation response: {message_id}")
+
+    try:
+        await _get_escalation_or_404(service, message_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Failed to open escalation event stream for {message_id}: {e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to open escalation event stream",
+        ) from e
+
+    async def event_stream() -> AsyncIterator[str]:
+        broker = _get_event_broker(request, service)
+        if broker is None:
+            escalation = await service.repository.get_by_message_id(message_id)
+            if escalation is None:
+                return
+            response = await _build_user_poll_response(
+                request=request,
+                escalation=escalation,
+                message_id=message_id,
+                settings=settings,
+            )
+            yield _format_sse_event("escalation", response)
+            return
+
+        async with broker.subscribe(message_id) as queue:
+            escalation = await service.repository.get_by_message_id(message_id)
+            if escalation is None:
+                return
+
+            response = await _build_user_poll_response(
+                request=request,
+                escalation=escalation,
+                message_id=message_id,
+                settings=settings,
+            )
+            yield _format_sse_event("escalation", response)
+            if _is_terminal_user_response(response):
+                return
+
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    escalation = await asyncio.wait_for(queue.get(), timeout=15)
+                except asyncio.TimeoutError:
+                    yield ": keep-alive\n\n"
+                    continue
+
+                response = await _build_user_poll_response(
+                    request=request,
+                    escalation=escalation,
+                    message_id=message_id,
+                    settings=settings,
+                )
+                yield _format_sse_event("escalation", response)
+                if _is_terminal_user_response(response):
+                    return
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.post(
     "/escalations/{message_id}/rate",
     response_model=UserPollResponse,
@@ -256,7 +378,7 @@ async def rate_staff_answer(
     message_id: str = Path(
         ...,
         description="Message ID from the original question",
-        pattern=r"^(?:[a-z]+_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        pattern=MESSAGE_ID_PATH_PATTERN,
     ),
     service=Depends(get_escalation_service),
     settings=Depends(get_settings),

--- a/api/app/services/escalation/escalation_event_broker.py
+++ b/api/app/services/escalation/escalation_event_broker.py
@@ -1,0 +1,49 @@
+"""In-process event fan-out for user-facing escalation updates."""
+
+import asyncio
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, DefaultDict, Set
+
+from app.models.escalation import Escalation
+
+
+class EscalationEventBroker:
+    """Publish latest escalation state to subscribers for one message ID."""
+
+    def __init__(self) -> None:
+        self._subscribers: DefaultDict[str, Set[asyncio.Queue[Escalation]]] = (
+            defaultdict(set)
+        )
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def subscribe(
+        self, message_id: str
+    ) -> AsyncIterator[asyncio.Queue[Escalation]]:
+        queue: asyncio.Queue[Escalation] = asyncio.Queue(maxsize=1)
+        async with self._lock:
+            self._subscribers[message_id].add(queue)
+
+        try:
+            yield queue
+        finally:
+            async with self._lock:
+                queues = self._subscribers.get(message_id)
+                if not queues:
+                    return
+                queues.discard(queue)
+                if not queues:
+                    self._subscribers.pop(message_id, None)
+
+    async def publish(self, escalation: Escalation) -> None:
+        async with self._lock:
+            queues = list(self._subscribers.get(escalation.message_id, set()))
+
+        for queue in queues:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            queue.put_nowait(escalation)

--- a/api/app/services/escalation/escalation_event_broker.py
+++ b/api/app/services/escalation/escalation_event_broker.py
@@ -30,11 +30,10 @@ class EscalationEventBroker:
         finally:
             async with self._lock:
                 queues = self._subscribers.get(message_id)
-                if not queues:
-                    return
-                queues.discard(queue)
-                if not queues:
-                    self._subscribers.pop(message_id, None)
+                if queues:
+                    queues.discard(queue)
+                    if not queues:
+                        self._subscribers.pop(message_id, None)
 
     async def publish(self, escalation: Escalation) -> None:
         async with self._lock:
@@ -46,4 +45,14 @@ class EscalationEventBroker:
                     queue.get_nowait()
                 except asyncio.QueueEmpty:
                     pass
-            queue.put_nowait(escalation)
+            try:
+                queue.put_nowait(escalation)
+            except asyncio.QueueFull:
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    queue.put_nowait(escalation)
+                except asyncio.QueueFull:
+                    pass

--- a/api/app/services/escalation/escalation_service.py
+++ b/api/app/services/escalation/escalation_service.py
@@ -67,6 +67,7 @@ class EscalationService:
         feedback_orchestrator=None,
         embeddings=None,
         rag_service=None,
+        event_broker=None,
     ):
         self.repository = repository
         self.response_delivery = response_delivery
@@ -76,6 +77,18 @@ class EscalationService:
         self.feedback_orchestrator = feedback_orchestrator
         self.embeddings = embeddings
         self.rag_service = rag_service
+        self.event_broker = event_broker
+
+    async def _publish_update(self, escalation: Escalation) -> None:
+        if self.event_broker is None:
+            return
+        try:
+            await self.event_broker.publish(escalation)
+        except Exception:
+            logger.exception(
+                "Failed to publish escalation event for message_id=%s",
+                escalation.message_id,
+            )
 
     # ------------------------------------------------------------------
     # Create
@@ -232,6 +245,7 @@ class EscalationService:
             ),
         )
         ESCALATION_LIFECYCLE.labels(action="responded").inc()
+        await self._publish_update(updated)
 
         # Track response time
         if escalation.created_at:
@@ -399,13 +413,14 @@ class EscalationService:
             return False
 
         now = datetime.now(timezone.utc)
-        await self.repository.update(
+        updated = await self.repository.update(
             escalation.id,
             EscalationUpdate(
                 status=EscalationStatus.CLOSED,
                 closed_at=now,
             ),
         )
+        await self._publish_update(updated)
         ESCALATION_LIFECYCLE.labels(action="auto_closed").inc()
         logger.info(
             "Auto-closed reaction escalation",
@@ -497,13 +512,15 @@ class EscalationService:
 
         now = datetime.now(timezone.utc)
         ESCALATION_LIFECYCLE.labels(action="closed").inc()
-        return await self.repository.update(
+        updated = await self.repository.update(
             escalation_id,
             EscalationUpdate(
                 status=EscalationStatus.CLOSED,
                 closed_at=now,
             ),
         )
+        await self._publish_update(updated)
+        return updated
 
     async def prioritize_escalation(
         self,

--- a/api/tests/escalation/test_escalation_event_broker.py
+++ b/api/tests/escalation/test_escalation_event_broker.py
@@ -55,3 +55,20 @@ async def test_publish_keeps_latest_event_when_subscriber_is_slow():
 
         received = await asyncio.wait_for(queue.get(), timeout=0.1)
         assert received.staff_answer == "Latest answer"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_publish_keeps_latest_event_for_same_message():
+    broker = EscalationEventBroker()
+    escalations = [
+        _make_escalation(staff_answer=f"Concurrent answer {index}")
+        for index in range(10)
+    ]
+
+    async with broker.subscribe(escalations[0].message_id) as queue:
+        await asyncio.gather(
+            *(broker.publish(escalation) for escalation in escalations)
+        )
+
+        received = await asyncio.wait_for(queue.get(), timeout=0.1)
+        assert received.staff_answer == "Concurrent answer 9"

--- a/api/tests/escalation/test_escalation_event_broker.py
+++ b/api/tests/escalation/test_escalation_event_broker.py
@@ -1,0 +1,57 @@
+"""Tests for web escalation event fan-out."""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from app.models.escalation import Escalation, EscalationStatus
+from app.services.escalation.escalation_event_broker import EscalationEventBroker
+
+
+def _make_escalation(**overrides) -> Escalation:
+    defaults = dict(
+        id=1,
+        message_id="550e8400-e29b-41d4-a716-446655440000",
+        channel="web",
+        user_id="web_user_123",
+        question="How do I restore?",
+        ai_draft_answer="Go to Settings.",
+        confidence_score=0.42,
+        routing_action="needs_human",
+        status=EscalationStatus.RESPONDED,
+        staff_answer="Open Settings and restore from seed words.",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        responded_at=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return Escalation(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_publish_delivers_only_to_matching_message_subscribers():
+    broker = EscalationEventBroker()
+    escalation = _make_escalation()
+    other = _make_escalation(message_id="550e8400-e29b-41d4-a716-446655440001")
+
+    async with broker.subscribe(escalation.message_id) as queue:
+        await broker.publish(other)
+        assert queue.empty()
+
+        await broker.publish(escalation)
+
+        received = await asyncio.wait_for(queue.get(), timeout=0.1)
+        assert received == escalation
+
+
+@pytest.mark.asyncio
+async def test_publish_keeps_latest_event_when_subscriber_is_slow():
+    broker = EscalationEventBroker()
+    first = _make_escalation(staff_answer="First answer")
+    latest = _make_escalation(staff_answer="Latest answer")
+
+    async with broker.subscribe(first.message_id) as queue:
+        await broker.publish(first)
+        await broker.publish(latest)
+
+        received = await asyncio.wait_for(queue.get(), timeout=0.1)
+        assert received.staff_answer == "Latest answer"

--- a/api/tests/escalation/test_escalation_service.py
+++ b/api/tests/escalation/test_escalation_service.py
@@ -537,6 +537,45 @@ class TestEscalationServiceRespond:
         mock_learning_engine.record_review.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_respond_publishes_web_event_immediately(
+        self,
+        mock_repository,
+        mock_faq_service,
+        mock_learning_engine,
+        mock_settings,
+        mock_rag_service,
+    ):
+        """Staff responses are pushed to web clients as soon as they are stored."""
+        broker = MagicMock()
+        broker.publish = AsyncMock()
+        svc = EscalationService(
+            repository=mock_repository,
+            response_delivery=None,
+            faq_service=mock_faq_service,
+            learning_engine=mock_learning_engine,
+            settings=mock_settings,
+            rag_service=mock_rag_service,
+            event_broker=broker,
+        )
+        claimed = _make_escalation(
+            status=EscalationStatus.IN_REVIEW,
+            staff_id="staff_1",
+            channel="web",
+        )
+        responded = _make_escalation(
+            status=EscalationStatus.RESPONDED,
+            staff_answer="Answer",
+            staff_id="staff_1",
+            channel="web",
+        )
+        mock_repository.get_by_id.return_value = claimed
+        mock_repository.update.return_value = responded
+
+        await svc.respond_to_escalation(1, "Answer", "staff_1")
+
+        broker.publish.assert_awaited_once_with(responded)
+
+    @pytest.mark.asyncio
     async def test_respond_delivery_failure_still_saves(
         self, service, mock_repository, mock_response_delivery
     ):
@@ -593,6 +632,47 @@ class TestEscalationServicePrioritize:
 
         with pytest.raises(EscalationClosedError):
             await service.prioritize_escalation(1, EscalationPriority.HIGH)
+
+
+# ---------------------------------------------------------------------------
+# Close
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationServiceCloseEvents:
+    """Test close event publishing."""
+
+    @pytest.mark.asyncio
+    async def test_close_publishes_web_event(
+        self,
+        mock_repository,
+        mock_faq_service,
+        mock_learning_engine,
+        mock_settings,
+        mock_rag_service,
+    ):
+        broker = MagicMock()
+        broker.publish = AsyncMock()
+        svc = EscalationService(
+            repository=mock_repository,
+            response_delivery=None,
+            faq_service=mock_faq_service,
+            learning_engine=mock_learning_engine,
+            settings=mock_settings,
+            rag_service=mock_rag_service,
+            event_broker=broker,
+        )
+        escalation = _make_escalation(status=EscalationStatus.IN_REVIEW)
+        closed = _make_escalation(
+            status=EscalationStatus.CLOSED,
+            closed_at=datetime.now(timezone.utc),
+        )
+        mock_repository.get_by_id.return_value = escalation
+        mock_repository.update.return_value = closed
+
+        await svc.close_escalation(1)
+
+        broker.publish.assert_awaited_once_with(closed)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/escalation/test_escalation_service.py
+++ b/api/tests/escalation/test_escalation_service.py
@@ -674,6 +674,45 @@ class TestEscalationServiceCloseEvents:
 
         broker.publish.assert_awaited_once_with(closed)
 
+    @pytest.mark.asyncio
+    async def test_auto_close_reaction_publishes_web_event(
+        self,
+        mock_repository,
+        mock_faq_service,
+        mock_learning_engine,
+        mock_settings,
+        mock_rag_service,
+    ):
+        broker = MagicMock()
+        broker.publish = AsyncMock()
+        svc = EscalationService(
+            repository=mock_repository,
+            response_delivery=None,
+            faq_service=mock_faq_service,
+            learning_engine=mock_learning_engine,
+            settings=mock_settings,
+            rag_service=mock_rag_service,
+            event_broker=broker,
+        )
+        pending = _make_escalation(
+            status=EscalationStatus.PENDING,
+            routing_reason="auto_reaction_negative:user_reported_incorrect(confidence=95%)",
+        )
+        closed = _make_escalation(
+            status=EscalationStatus.CLOSED,
+            closed_at=datetime.now(timezone.utc),
+        )
+        mock_repository.get_by_message_id.return_value = pending
+        mock_repository.update.return_value = closed
+
+        result = await svc.auto_close_reaction_escalation(
+            message_id=pending.message_id,
+            reason="reaction_removed",
+        )
+
+        assert result is True
+        broker.publish.assert_awaited_once_with(closed)
+
 
 # ---------------------------------------------------------------------------
 # Generate FAQ

--- a/api/tests/routes/test_escalation_endpoints.py
+++ b/api/tests/routes/test_escalation_endpoints.py
@@ -79,6 +79,7 @@ def temp_db_path():
 def mock_escalation_service():
     """Create a mock escalation service."""
     service = MagicMock()
+    service.event_broker = None
 
     # Mock sample escalation data
     sample_escalation = Escalation(
@@ -836,6 +837,53 @@ class TestPollingEndpoint:
         assert data["resolution"] == "responded"
         assert data["responded_at"] is not None
         assert data["closed_at"] is not None
+
+    def test_events_stream_returns_current_resolved_answer(
+        self, polling_client, mock_escalation_service
+    ):
+        """SSE sends the current resolved state immediately on connect."""
+        responded_escalation = Escalation(
+            id=1,
+            message_id="12345678-1234-1234-1234-123456789abc",
+            channel="web",
+            user_id="@user:matrix.org",
+            username="testuser",
+            channel_metadata={},
+            question="Test question",
+            ai_draft_answer="Draft answer",
+            confidence_score=0.65,
+            routing_action="needs_human",
+            routing_reason=None,
+            sources=[],
+            staff_answer="Final staff answer",
+            staff_id="admin1",
+            delivery_status=EscalationDeliveryStatus.DELIVERED,
+            delivery_error=None,
+            delivery_attempts=1,
+            last_delivery_at=datetime(2025, 1, 15, 12, 30, 0),
+            generated_faq_id=None,
+            status=EscalationStatus.RESPONDED,
+            priority=EscalationPriority.NORMAL,
+            created_at=datetime(2025, 1, 15, 10, 0, 0),
+            claimed_at=datetime(2025, 1, 15, 11, 0, 0),
+            responded_at=datetime(2025, 1, 15, 12, 0, 0),
+            closed_at=None,
+        )
+        mock_escalation_service.repository.get_by_message_id.return_value = (
+            responded_escalation
+        )
+
+        with polling_client.stream(
+            "GET",
+            "/escalations/12345678-1234-1234-1234-123456789abc/events",
+        ) as response:
+            body = "".join(response.iter_text())
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert "event: escalation" in body
+        assert '"status":"resolved"' in body
+        assert '"staff_answer":"Final staff answer"' in body
 
     def test_poll_invalid_uuid_returns_422(self, polling_client):
         """Test polling with invalid UUID format returns 422."""

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -140,6 +140,31 @@ server {
     }
 
     #------------------------------
+    # Escalation Response Events (SSE)
+    #------------------------------
+    # EventSource keeps the connection open while a user waits for staff review.
+    # Disable proxy buffering explicitly so accepted staff answers are delivered
+    # immediately instead of waiting for polling or buffered response flushes.
+    location ~ "^/api/escalations/([a-z]+_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/events$" {
+        limit_req zone=api burst=20 nodelay;
+
+        rewrite ^/api/(.*)$ /$1 break;
+
+        proxy_pass http://api:8000;
+
+        include /etc/nginx/conf.d/snippets/proxy-params.conf;
+        include /etc/nginx/conf.d/snippets/connection-limits.conf;
+        include /etc/nginx/conf.d/snippets/security-headers-api.conf;
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        gzip off;
+        add_header X-Accel-Buffering no always;
+    }
+
+    #------------------------------
     # API Backend
     #------------------------------
     location /api/ {

--- a/docker/nginx/conf.d/default.prod.conf
+++ b/docker/nginx/conf.d/default.prod.conf
@@ -166,6 +166,33 @@ server {
     }
 
     #------------------------------
+    # Escalation Response Events (SSE)
+    #------------------------------
+    # EventSource keeps the connection open while a user waits for staff review.
+    # Disable proxy buffering explicitly so accepted staff answers are delivered
+    # immediately instead of waiting for polling or buffered response flushes.
+    location ~ "^/api/escalations/([a-z]+_)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/events$" {
+        limit_req zone=api burst=20 nodelay;
+
+        rewrite ^/api/(.*)$ /$1 break;
+
+        proxy_pass http://api:8000;
+
+        include /etc/nginx/conf.d/snippets/proxy-params.conf;
+        include /etc/nginx/conf.d/snippets/connection-limits.conf;
+        include /etc/nginx/conf.d/snippets/security-headers-api.conf;
+
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        gzip off;
+        add_header X-Accel-Buffering no always;
+
+        error_page 502 503 504 = @maintenance;
+    }
+
+    #------------------------------
     # API Backend
     #------------------------------
     location /api/ {

--- a/web/src/app/admin/escalations/page.tsx
+++ b/web/src/app/admin/escalations/page.tsx
@@ -68,6 +68,7 @@ export interface EscalationItem {
     content?: string | null
     protocol?: string | null
     section?: string | null
+    page_type?: string | null
   }>
   created_at: string
   claimed_at?: string | null

--- a/web/src/app/admin/manage-feedback/page.tsx
+++ b/web/src/app/admin/manage-feedback/page.tsx
@@ -294,7 +294,7 @@ export default function ManageFeedbackPage() {
     const params = new URLSearchParams();
     Object.entries(adjustedFilters).forEach(([key, value]) => {
       if (value !== undefined && value !== null && value !== '' && value !== 'all' &&
-          !(Array.isArray(value) && value.length === 0) && value !== false) {
+          !(Array.isArray(value) && value.length === 0)) {
         if (Array.isArray(value)) {
           params.append(key, value.join(','));
         } else if (value instanceof Date) {

--- a/web/src/app/admin/training/page.tsx
+++ b/web/src/app/admin/training/page.tsx
@@ -20,6 +20,7 @@ import type {
   QueueCounts,
   RoutingCategory,
   SimilarFAQ,
+  BatchCandidate,
   UnifiedCandidate,
 } from '@/components/admin/training/types';
 
@@ -286,9 +287,13 @@ export default function TrainingPage() {
   };
 
   // Handle expand item from batch view
-  const handleExpandBatchItem = (candidate: UnifiedCandidate) => {
+  const handleExpandBatchItem = (candidate: BatchCandidate) => {
+    const fullCandidate = batchItems.find((item) => item.id === candidate.id);
+    if (!fullCandidate) {
+      return;
+    }
     setIsBatchMode(false);
-    setCurrentItem(candidate);
+    setCurrentItem(fullCandidate);
   };
 
   // Handle approve action - unified endpoint

--- a/web/src/components/admin/overview/OverviewClient.test.tsx
+++ b/web/src/components/admin/overview/OverviewClient.test.tsx
@@ -12,7 +12,10 @@ jest.mock("lucide-react", () => {
   return new Proxy({}, { get: () => MockIcon });
 });
 
-const mockTrustMonitoringCardSpy = jest.fn(() => <div>trust-monitor-card</div>);
+const mockTrustMonitoringCardSpy = jest.fn((props: unknown) => {
+  void props;
+  return <div>trust-monitor-card</div>;
+});
 
 jest.mock("@/components/admin/overview/TrustMonitoringCard", () => ({
   TrustMonitoringCard: (props: unknown) => mockTrustMonitoringCardSpy(props),

--- a/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
+++ b/web/src/components/admin/overview/TrustMonitoringCard.test.tsx
@@ -1,4 +1,5 @@
 import { cloneElement, createContext, isValidElement, useContext, useState } from "react";
+import type { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TrustMonitoringCard } from "./TrustMonitoringCard";
@@ -122,7 +123,7 @@ jest.mock("@/components/ui/collapsible", () => ({
   CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => {
     const context = useContext(CollapsibleContext);
     if (isValidElement(children)) {
-      return cloneElement(children, {
+      return cloneElement(children as ReactElement<{ onClick?: () => void }>, {
         onClick: () => context?.setOpen(!context.open),
       });
     }

--- a/web/src/components/admin/training/TrainingReviewItem.tsx
+++ b/web/src/components/admin/training/TrainingReviewItem.tsx
@@ -669,7 +669,7 @@ export function TrainingReviewItem({
                 <>
                   <MarkdownContent content={cleanedGeneratedAnswer} className="text-sm" />
                   {/* Sources and Confidence */}
-                  {(pair.generated_answer_sources?.length > 0 || pair.generation_confidence !== null) && (
+                  {((pair.generated_answer_sources?.length ?? 0) > 0 || pair.generation_confidence !== null) && (
                     <div className="mt-3 pt-3 border-t border-border/50 flex flex-wrap items-center gap-3">
                       {pair.generated_answer_sources && pair.generated_answer_sources.length > 0 && (
                         <SourceBadges sources={pair.generated_answer_sources} />

--- a/web/src/components/chat/components/markdown-content.tsx
+++ b/web/src/components/chat/components/markdown-content.tsx
@@ -19,6 +19,7 @@ import { memo, useMemo, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { Components } from 'react-markdown';
 
 // Dynamic import with SSR disabled - react-markdown only needed client-side
 const ReactMarkdown = dynamic(() => import('react-markdown'), {
@@ -115,18 +116,12 @@ function CustomLink({
   );
 }
 
-function CustomImage({
-  src,
-  alt,
-}: {
-  src?: string;
-  alt?: string;
-}) {
-  const safeSrc = getSafeImageSrc(src);
+function CustomImage({ src, alt }: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const safeSrc = getSafeImageSrc(typeof src === 'string' ? src : undefined);
   if (!safeSrc) return null;
 
   // eslint-disable-next-line @next/next/no-img-element
-  return <img src={safeSrc} alt={alt ?? ''} loading="lazy" />;
+  return <img src={safeSrc} alt={typeof alt === 'string' ? alt : ''} loading="lazy" />;
 }
 
 /**
@@ -145,16 +140,14 @@ export const MarkdownContent = memo(function MarkdownContent({
   className,
 }: MarkdownContentProps) {
   // Stable reference for custom components - prevents ReactMarkdown re-initialization
-  const components = useMemo(
+  const components = useMemo<Components>(
     () => ({
       // Custom link with external indicator and security
       a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
         <CustomLink href={href}>{children}</CustomLink>
       ),
       // Custom image guard to avoid `src=""` warnings and block unsafe schemes
-      img: ({ src, alt }: { src?: string; alt?: string }) => (
-        <CustomImage src={src} alt={alt} />
-      ),
+      img: CustomImage,
     }),
     []
   );

--- a/web/src/components/chat/hooks/use-escalation-polling.test.tsx
+++ b/web/src/components/chat/hooks/use-escalation-polling.test.tsx
@@ -1,0 +1,117 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { useEscalationPolling } from "./use-escalation-polling";
+
+const MESSAGE_ID = "12345678-1234-1234-1234-123456789abc";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  readonly close = jest.fn();
+  private readonly listeners = new Map<string, Array<(event: MessageEvent) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(eventName: string, listener: (event: MessageEvent) => void) {
+    const listeners = this.listeners.get(eventName) ?? [];
+    listeners.push(listener);
+    this.listeners.set(eventName, listeners);
+  }
+
+  emit(eventName: string, data: unknown) {
+    const event = { data: JSON.stringify(data) } as MessageEvent;
+    for (const listener of this.listeners.get(eventName) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function Harness({
+  enabled = true,
+  messageId = MESSAGE_ID,
+}: {
+  enabled?: boolean;
+  messageId?: string | null;
+}) {
+  const result = useEscalationPolling(messageId, enabled);
+
+  return (
+    <div>
+      <div data-testid="status">{result.status}</div>
+      <div data-testid="answer">{result.staffAnswer ?? ""}</div>
+      <div data-testid="resolution">{result.resolution ?? ""}</div>
+      <div data-testid="rate-token">{result.rateToken ?? ""}</div>
+    </div>
+  );
+}
+
+describe("useEscalationPolling", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    Object.defineProperty(window, "EventSource", {
+      configurable: true,
+      writable: true,
+      value: MockEventSource,
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (window as Window & { EventSource?: typeof EventSource }).EventSource;
+  });
+
+  test("resolves immediately from the escalation SSE stream", async () => {
+    render(<Harness />);
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe(
+      `/api/escalations/${MESSAGE_ID}/events`,
+    );
+
+    act(() => {
+      MockEventSource.instances[0].emit("escalation", {
+        status: "resolved",
+        staff_answer: "Staff answer",
+        responded_at: "2026-06-12T10:00:00Z",
+        resolution: "responded",
+        rate_token: "signed-token",
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("answer")).toHaveTextContent("Staff answer"),
+    );
+    expect(screen.getByTestId("status")).toHaveTextContent("resolved");
+    expect(screen.getByTestId("resolution")).toHaveTextContent("responded");
+    expect(screen.getByTestId("rate-token")).toHaveTextContent("signed-token");
+    expect(MockEventSource.instances[0].close).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("falls back to polling when EventSource is unavailable", async () => {
+    delete (window as Window & { EventSource?: typeof EventSource }).EventSource;
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "resolved",
+        staff_answer: "Fallback answer",
+        responded_at: "2026-06-12T10:00:00Z",
+        resolution: "responded",
+      }),
+    });
+
+    render(<Harness />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("answer")).toHaveTextContent("Fallback answer"),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      `/api/escalations/${MESSAGE_ID}/response`,
+    );
+  });
+});

--- a/web/src/components/chat/hooks/use-escalation-polling.ts
+++ b/web/src/components/chat/hooks/use-escalation-polling.ts
@@ -1,152 +1,218 @@
 /**
- * Hook for polling escalation status for a specific message.
- * Polls the API at adaptive intervals to check if staff has responded.
+ * Hook for resolving a web-chat escalation.
+ * Uses SSE for instant staff responses and keeps polling as a safe fallback.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react"
-import { API_BASE_URL } from "@/lib/config"
+import { useCallback, useEffect, useRef, useState } from "react";
+import { API_BASE_URL } from "@/lib/config";
 
-type PollingStatus = 'idle' | 'polling' | 'resolved'
-type PollingResolution = 'responded' | 'closed' | null
+type PollingStatus = "idle" | "polling" | "resolved";
+type PollingResolution = "responded" | "closed" | null;
 
 interface EscalationPollResult {
-  status: PollingStatus
-  staffAnswer: string | null
-  respondedAt: string | null
-  resolution: PollingResolution
-  staffAnswerRating: number | null
-  rateToken: string | null
-  userLanguage: string | null
+  status: PollingStatus;
+  staffAnswer: string | null;
+  respondedAt: string | null;
+  resolution: PollingResolution;
+  staffAnswerRating: number | null;
+  rateToken: string | null;
+  userLanguage: string | null;
 }
 
 interface PollResponse {
-  status: 'pending' | 'resolved'
-  staff_answer?: string
-  responded_at?: string
-  resolution?: 'responded' | 'closed'
-  closed_at?: string
-  staff_answer_rating?: number
-  rate_token?: string
-  user_language?: string
+  status: "pending" | "resolved";
+  staff_answer?: string;
+  responded_at?: string;
+  resolution?: "responded" | "closed";
+  closed_at?: string;
+  staff_answer_rating?: number;
+  rate_token?: string;
+  user_language?: string;
 }
 
-// Polling intervals in milliseconds
-const INITIAL_INTERVAL = 10_000     // 10 seconds
-const ACTIVE_INTERVAL = 30_000      // 30 seconds
-const BACKGROUND_INTERVAL = 60_000  // 60 seconds
-const POLL_TIMEOUT = 30 * 60_000    // 30 minutes
+const INITIAL_INTERVAL = 10_000;
+const ACTIVE_INTERVAL = 30_000;
+const BACKGROUND_INTERVAL = 60_000;
+const POLL_TIMEOUT = 30 * 60_000;
+
+function escalationUrl(messageId: string, suffix: "events" | "response") {
+  return `${API_BASE_URL}/escalations/${messageId}/${suffix}`;
+}
 
 export function useEscalationPolling(
   messageId: string | null,
-  enabled: boolean
+  enabled: boolean,
 ): EscalationPollResult {
-  const [status, setStatus] = useState<PollingStatus>('idle')
-  const [staffAnswer, setStaffAnswer] = useState<string | null>(null)
-  const [respondedAt, setRespondedAt] = useState<string | null>(null)
-  const [resolution, setResolution] = useState<PollingResolution>(null)
-  const [staffAnswerRating, setStaffAnswerRating] = useState<number | null>(null)
-  const [rateToken, setRateToken] = useState<string | null>(null)
-  const [userLanguage, setUserLanguage] = useState<string | null>(null)
+  const [status, setStatus] = useState<PollingStatus>("idle");
+  const [staffAnswer, setStaffAnswer] = useState<string | null>(null);
+  const [respondedAt, setRespondedAt] = useState<string | null>(null);
+  const [resolution, setResolution] = useState<PollingResolution>(null);
+  const [staffAnswerRating, setStaffAnswerRating] = useState<number | null>(null);
+  const [rateToken, setRateToken] = useState<string | null>(null);
+  const [userLanguage, setUserLanguage] = useState<string | null>(null);
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const startTimeRef = useRef<number>(0)
-  const pollCountRef = useRef<number>(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const startTimeRef = useRef<number>(0);
+  const pollCountRef = useRef<number>(0);
+
+  const cleanupPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
 
   const cleanup = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
-      intervalRef.current = null
+    cleanupPolling();
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
     }
-  }, [])
+  }, [cleanupPolling]);
+
+  const resetResolvedState = useCallback(() => {
+    setStaffAnswer(null);
+    setRespondedAt(null);
+    setResolution(null);
+    setStaffAnswerRating(null);
+    setRateToken(null);
+    setUserLanguage(null);
+  }, []);
+
+  const applyResponse = useCallback((data: PollResponse): boolean => {
+    if (data.status !== "resolved") {
+      return false;
+    }
+
+    setStatus("resolved");
+    setResolution(data.staff_answer ? "responded" : (data.resolution ?? null));
+    setStaffAnswer(data.staff_answer ?? null);
+    setRespondedAt(data.responded_at || data.closed_at || null);
+    setStaffAnswerRating(data.staff_answer_rating ?? null);
+    setRateToken(data.rate_token ?? null);
+    setUserLanguage(data.user_language ?? null);
+
+    return Boolean(data.staff_answer || data.resolution === "closed");
+  }, []);
 
   const poll = useCallback(async () => {
-    if (!messageId) return
+    if (!messageId) return;
 
-    // Check timeout
-    const elapsed = Date.now() - startTimeRef.current
+    const elapsed = Date.now() - startTimeRef.current;
     if (elapsed > POLL_TIMEOUT) {
-      cleanup()
-      return
+      cleanup();
+      return;
     }
 
     try {
-      const response = await fetch(`${API_BASE_URL}/escalations/${messageId}/response`)
+      const response = await fetch(escalationUrl(messageId, "response"));
 
-      if (!response.ok) return
+      if (!response.ok) return;
 
-      const data: PollResponse = await response.json()
-
-      if (data.status === 'resolved') {
-        setStatus('resolved')
-        setResolution(data.staff_answer ? 'responded' : (data.resolution ?? null))
-        setStaffAnswer(data.staff_answer ?? null)
-        setRespondedAt(data.responded_at || data.closed_at || null)
-        setStaffAnswerRating(data.staff_answer_rating ?? null)
-        setRateToken(data.rate_token ?? null)
-        setUserLanguage(data.user_language ?? null)
-
-        // Terminal states:
-        // - resolved+staff_answer: staff responded
-        // - resolved+resolution=closed: closed/dismissed without reply
-        if (data.staff_answer || data.resolution === "closed") {
-          cleanup()
-        }
+      const data: PollResponse = await response.json();
+      if (applyResponse(data)) {
+        cleanup();
       }
     } catch {
-      // Silently continue polling on error
+      // Keep the fallback loop alive on transient API/network errors.
     }
 
-    pollCountRef.current += 1
-  }, [messageId, cleanup])
+    pollCountRef.current += 1;
+  }, [messageId, cleanup, applyResponse]);
 
   useEffect(() => {
     if (!enabled || !messageId) {
-      setStatus('idle')
-      cleanup()
-      return
+      setStatus("idle");
+      resetResolvedState();
+      cleanup();
+      return;
     }
 
-    setStatus('polling')
-    startTimeRef.current = Date.now()
-    pollCountRef.current = 0
+    let active = true;
 
-    // Initial poll
-    poll()
-
-    // Determine interval based on visibility
     const getInterval = () => {
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
-        return BACKGROUND_INTERVAL
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return BACKGROUND_INTERVAL;
       }
-      // Use initial interval for first 5 polls, then active interval
-      return pollCountRef.current < 5 ? INITIAL_INTERVAL : ACTIVE_INTERVAL
-    }
+      return pollCountRef.current < 5 ? INITIAL_INTERVAL : ACTIVE_INTERVAL;
+    };
 
-    // Start polling with adaptive interval
     const startPolling = () => {
-      cleanup()
+      cleanupPolling();
+      void poll();
       intervalRef.current = setInterval(() => {
-        poll()
-      }, getInterval())
-    }
+        void poll();
+      }, getInterval());
+    };
 
-    startPolling()
-
-    // Adjust interval on visibility change
-    const handleVisibilityChange = () => {
-      if (status !== 'resolved') {
-        startPolling()
+    const startEventStream = () => {
+      const EventSourceCtor =
+        typeof window !== "undefined" ? window.EventSource : undefined;
+      if (!EventSourceCtor) {
+        startPolling();
+        return;
       }
-    }
 
-    document.addEventListener('visibilitychange', handleVisibilityChange)
+      const source = new EventSourceCtor(escalationUrl(messageId, "events"));
+      eventSourceRef.current = source;
+
+      const handleEvent = (event: MessageEvent) => {
+        if (!active) return;
+        try {
+          const data = JSON.parse(event.data) as PollResponse;
+          if (applyResponse(data)) {
+            cleanup();
+          }
+        } catch {
+          cleanup();
+          startPolling();
+        }
+      };
+
+      const handleError = () => {
+        if (!active || eventSourceRef.current !== source) return;
+        source.close();
+        eventSourceRef.current = null;
+        startPolling();
+      };
+
+      source.addEventListener("escalation", handleEvent);
+      source.addEventListener("message", handleEvent);
+      source.addEventListener("error", handleError);
+    };
+
+    setStatus("polling");
+    resetResolvedState();
+    startTimeRef.current = Date.now();
+    pollCountRef.current = 0;
+    startEventStream();
+
+    const handleVisibilityChange = () => {
+      if (intervalRef.current) {
+        startPolling();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      cleanup()
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messageId, enabled])
+      active = false;
+      cleanup();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [
+    messageId,
+    enabled,
+    poll,
+    applyResponse,
+    cleanup,
+    cleanupPolling,
+    resetResolvedState,
+  ]);
 
   return {
     status,
@@ -156,5 +222,5 @@ export function useEscalationPolling(
     staffAnswerRating,
     rateToken,
     userLanguage,
-  }
+  };
 }

--- a/web/src/components/chat/hooks/use-escalation-polling.ts
+++ b/web/src/components/chat/hooks/use-escalation-polling.ts
@@ -51,15 +51,17 @@ export function useEscalationPolling(
   const [rateToken, setRateToken] = useState<string | null>(null);
   const [userLanguage, setUserLanguage] = useState<string | null>(null);
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollingActiveRef = useRef<boolean>(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const startTimeRef = useRef<number>(0);
   const pollCountRef = useRef<number>(0);
 
   const cleanupPolling = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+    pollingActiveRef.current = false;
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
     }
   }, []);
 
@@ -143,10 +145,18 @@ export function useEscalationPolling(
 
     const startPolling = () => {
       cleanupPolling();
-      void poll();
-      intervalRef.current = setInterval(() => {
-        void poll();
-      }, getInterval());
+      pollingActiveRef.current = true;
+
+      const runAndSchedule = async () => {
+        await poll();
+        if (!active || !pollingActiveRef.current) return;
+
+        pollingTimeoutRef.current = setTimeout(() => {
+          void runAndSchedule();
+        }, getInterval());
+      };
+
+      void runAndSchedule();
     };
 
     const startEventStream = () => {
@@ -192,7 +202,7 @@ export function useEscalationPolling(
     startEventStream();
 
     const handleVisibilityChange = () => {
-      if (intervalRef.current) {
+      if (pollingActiveRef.current) {
         startPolling();
       }
     };

--- a/web/src/hooks/useChannelAutoresponsePolicies.ts
+++ b/web/src/hooks/useChannelAutoresponsePolicies.ts
@@ -8,6 +8,7 @@ import {
 } from "@/components/admin/overview/types";
 import { makeAuthenticatedRequest } from "@/lib/auth";
 
+export type { ChannelAutoresponsePolicy };
 export type ChannelResponseMode = "off" | "review" | "auto";
 export type ChannelAcknowledgmentMode = ChannelAutoresponsePolicy["acknowledgment_mode"];
 export type ChannelEscalationUserNoticeMode = ChannelAutoresponsePolicy["escalation_user_notice_mode"];

--- a/web/src/hooks/useTrustMonitorPolicy.test.tsx
+++ b/web/src/hooks/useTrustMonitorPolicy.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { makeAuthenticatedRequest } from "@/lib/auth";
+import type { TrustMonitorPolicy } from "@/components/admin/security/types";
 import { useTrustMonitorPolicy } from "./useTrustMonitorPolicy";
 
 jest.mock("@/lib/auth", () => ({
@@ -16,7 +17,7 @@ function mockJsonResponse(payload: unknown, status = 200): Response {
   } as Response;
 }
 
-const POLICY = {
+const POLICY: TrustMonitorPolicy = {
   enabled: true,
   name_collision_enabled: true,
   silent_observer_enabled: true,
@@ -32,7 +33,7 @@ const POLICY = {
   aggregate_ttl_days: 30,
   finding_ttl_days: 30,
   updated_at: "2026-03-20T10:00:00Z",
-} as const;
+};
 
 describe("useTrustMonitorPolicy", () => {
   beforeEach(() => {

--- a/web/src/test-globals.d.ts
+++ b/web/src/test-globals.d.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/web/tests/e2e/bisq-version-handling.spec.ts
+++ b/web/tests/e2e/bisq-version-handling.spec.ts
@@ -71,7 +71,7 @@ test.describe("Bisq Version Handling", () => {
         );
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         expect(responseLower).not.toContain(
@@ -93,7 +93,7 @@ test.describe("Bisq Version Handling", () => {
         const responseText = await askQuestionAndGetResponse(page, "How do I trade?");
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         const mentionsBisq2 = /bisq 2|bisq2|bisq easy/.test(responseLower);
@@ -113,7 +113,7 @@ test.describe("Bisq Version Handling", () => {
         const responseText = await askQuestionAndGetResponse(page, "What is Bisq 2?");
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         expect(responseLower).toMatch(/bisq 2|bisq2/);
@@ -126,7 +126,7 @@ test.describe("Bisq Version Handling", () => {
         const secondResponse = await askQuestionAndGetResponse(page, "How about in Bisq 1?");
         const responseLower = secondResponse.toLowerCase();
         if (isEscalationNotice(secondResponse)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         const handlesBisq1Context =
@@ -146,7 +146,7 @@ test.describe("Bisq Version Handling", () => {
         );
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         expect(responseLower).toMatch(/bisq 1|bisq1/);
@@ -171,7 +171,7 @@ test.describe("Bisq Version Handling", () => {
         const responseText = await askQuestionAndGetResponse(page, "How do I use Bisq1?");
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         const handlesBisq1 =
@@ -201,7 +201,7 @@ test.describe("Bisq Version Handling", () => {
         );
         const responseLower = responseText.toLowerCase();
         if (isEscalationNotice(responseText)) {
-            test.skip("Escalated: not applicable for low-confidence version-specific asks");
+            test.skip(true, "Escalated: not applicable for low-confidence version-specific asks");
         }
 
         expect(responseLower).not.toContain(


### PR DESCRIPTION
## Summary
- add a message-scoped in-process escalation event broker and public SSE endpoint for web-chat escalation updates
- switch the web-chat escalation hook to EventSource with the existing polling endpoint as fallback
- add nginx no-buffering routing for `/api/escalations/{message_id}/events` so production delivers staff responses immediately
- add API and web tests for event fan-out, SSE responses, and polling fallback
- include small existing type/lint fixes required to keep the branch green

## Why
Accepted staff answers currently rely on polling and can take roughly one polling interval to appear in the user web chat. The new path keeps the existing polling contract but streams escalation state changes immediately when the support admin accepts or closes an escalation.

## Browser validation
- Tested locally in browser through the Next dev `/api` path: accepted staff response appeared without waiting for the 30s polling interval.
- Tested through a temporary nginx container using the production-style `/api/escalations/{message_id}/events` route: pending event arrived in ~17ms and the resolved staff-answer event arrived ~579ms after backend `responded_at`.

## Checks
- `cd web && npm run lint`
- `cd web && npx tsc --noEmit --pretty false`
- `cd web && npm run test`
- `cd web && npm run build`
- `cd api && pytest tests/`
- `cd api && pre-commit run --all-files`
- `git diff --check`
- nginx syntax checks for local and production configs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Server-Sent Events (SSE) streaming for real-time escalation status updates with automatic HTTP polling fallback for environments without SSE support.
  * Introduced event broker system for escalation lifecycle updates.

* **Bug Fixes**
  * Fixed query parameter filtering to preserve `false` boolean values.
  * Improved rendering conditions for content blocks in training reviews.
  * Enhanced markdown image handling with safer attribute derivation.

* **Tests**
  * Added comprehensive test coverage for escalation event streaming and polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->